### PR TITLE
Fix opacity action (missing actionModel)

### DIFF
--- a/__TESTS__/unit/toJson/adjust.toJson.test.ts
+++ b/__TESTS__/unit/toJson/adjust.toJson.test.ts
@@ -68,4 +68,15 @@ describe('Adjust toJson()', () => {
       }
     ]});
   });
+
+  it('adjust.opacity', () => {
+    const transformation = new Transformation()
+      .addAction(Adjust.opacity(45));
+    expect(transformation.toJson()).toStrictEqual({actions:[
+      {
+        actionType: 'opacity',
+        level: 45
+      }
+    ]});
+  });
 });

--- a/src/actions/adjust/OpacityAdjustAction.ts
+++ b/src/actions/adjust/OpacityAdjustAction.ts
@@ -1,5 +1,7 @@
 import {Action} from "../../internal/Action.js";
 import {Qualifier} from "../../internal/qualifier/Qualifier.js";
+import {OpacityActionModel} from "../../internal/models/IOpacityActionModel.js";
+import {IActionModel} from "../../internal/models/IActionModel.js";
 
 /**
  * @description OpacityAction class, used to define the opacity of an asset
@@ -7,9 +9,22 @@ import {Qualifier} from "../../internal/qualifier/Qualifier.js";
  * @extends SDK.Action
  */
 class OpacityAdjustAction extends Action {
+  private level: number;
+  protected _actionModel: OpacityActionModel = {actionType: 'opacity'};
+
   constructor(level: number) {
     super();
+    this.level = level;
+    this._actionModel.level = level;
     this.addQualifier(new Qualifier('o', level));
+  }
+
+  static fromJson(actionModel: IActionModel): OpacityAdjustAction {
+    const { level } = (actionModel as OpacityActionModel);
+
+    // We are using this() to allow inheriting classes to use super.fromJson.apply(this, [actionModel])
+    // This allows the inheriting classes to determine the class to be created
+    return new this(level);
   }
 }
 

--- a/src/internal/models/IOpacityActionModel.ts
+++ b/src/internal/models/IOpacityActionModel.ts
@@ -1,0 +1,7 @@
+import {IActionModel} from "./IActionModel.js";
+
+interface OpacityActionModel extends IActionModel {
+  level?: number;
+}
+
+export {OpacityActionModel};


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
Add missing `_actionModel` to the Opacity action.

_(bug reference: ME-4642)_

#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
