### PR TITLE
Align RoundCorners action with the specs

### DIFF
--- a/__TESTS__/unit/fromJson/border.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/border.fromJson.test.ts
@@ -1,0 +1,39 @@
+import {fromJson} from "../../../src/internal/fromJson";
+
+describe('border.fromJson', () => {
+  it('should generate a url with border from array of models', function () {
+    const transformation = fromJson({actions:
+        [ {
+          actionType: 'border',
+          borderType: 'solid',
+          borderWidth: 5,
+          borderColor: 'red',
+        },
+        {
+          actionType: 'border',
+          borderType: 'solid',
+          borderWidth: 5,
+          borderColor: 'red',
+          roundCorners: {
+            actionType: 'roundCorners',
+            radius: [10, 20, 30, 40]
+          }
+        },
+        {
+          actionType: 'border',
+          borderType: 'solid',
+          borderWidth: 10,
+          borderColor: 'blue',
+          roundCorners: {
+            actionType: 'roundCorners',
+            radius: 'max'
+          }
+        },
+        ]}
+    );
+    expect(transformation.toString()).toStrictEqual(
+      'bo_5px_solid_red/bo_5px_solid_red,r_10:20:30:40/bo_10px_solid_blue,r_max'
+    );
+  });
+});
+

--- a/__TESTS__/unit/fromJson/roundCorners.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/roundCorners.fromJson.test.ts
@@ -1,0 +1,26 @@
+import {fromJson} from "../../../src/internal/fromJson";
+
+describe('roundCorners.fromJson', () => {
+  it('should generate a url with round corners from array of models', function () {
+    const transformation = fromJson({actions:
+      [
+        {
+          actionType: 'roundCorners',
+          radius: [10]
+        },
+        {
+          actionType: 'roundCorners',
+          radius: [10, 20, 30, 40]
+        },
+        {
+          actionType: 'roundCorners',
+          radius: 'max'
+        }
+      ]}
+    );
+    expect(transformation.toString()).toStrictEqual(
+      'r_10/r_10:20:30:40/r_max'
+    );
+  });
+});
+

--- a/__TESTS__/unit/toJson/border.toJson.test.ts
+++ b/__TESTS__/unit/toJson/border.toJson.test.ts
@@ -1,0 +1,65 @@
+import {Transformation} from "../../../src";
+import {RoundCorners} from "../../../src/actions";
+import {Border} from "../../../src/actions";
+
+describe('RoundCorners toJson()', () => {
+  it('roundCorners', () => {
+    const transformation = new Transformation()
+      .addAction(Border.solid(5, 'black'))
+      .addAction(Border.roundCorners(RoundCorners.max()))
+      .addAction(Border.roundCorners(RoundCorners.byRadius(10, 20, 30)))
+      .addAction(Border.solid(5, 'black').roundCorners(RoundCorners.max()))
+      .addAction(Border.roundCorners(RoundCorners.max()).solid(5, 'black'));
+
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'border',
+          borderWidth: 5,
+          borderColor: 'black',
+          borderType: 'solid'
+        },
+        {
+          actionType: 'border',
+          borderWidth: 0,
+          borderColor: 'transparent',
+          borderType: 'solid',
+          roundCorners: {
+            actionType: 'roundCorners',
+            radius: 'max'
+          }
+        },
+        {
+          actionType: 'border',
+          borderWidth: 0,
+          borderColor: 'transparent',
+          borderType: 'solid',
+          roundCorners: {
+            actionType: 'roundCorners',
+            radius: [10, 20, 30]
+          }
+        },
+        {
+          actionType: 'border',
+          borderWidth: 5,
+          borderColor: 'black',
+          borderType: 'solid',
+          roundCorners: {
+            actionType: 'roundCorners',
+            radius: 'max'
+          }
+        },
+        {
+          actionType: 'border',
+          borderWidth: 5,
+          borderColor: 'black',
+          borderType: 'solid',
+          roundCorners: {
+            actionType: 'roundCorners',
+            radius: 'max'
+          }
+        },
+      ]
+    });
+  });
+});

--- a/__TESTS__/unit/toJson/roundCorners.toJson.test.ts
+++ b/__TESTS__/unit/toJson/roundCorners.toJson.test.ts
@@ -1,0 +1,28 @@
+import {Transformation} from "../../../src";
+import {RoundCorners} from "../../../src/actions";
+
+describe('RoundCorners toJson()', () => {
+  it('roundCorners', () => {
+    const transformation = new Transformation()
+      .addAction(RoundCorners.byRadius(10))
+      .addAction(RoundCorners.byRadius(10, 20, 30, 40))
+      .addAction(RoundCorners.max());
+
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'roundCorners',
+          radius: [10, undefined, undefined, undefined]
+        },
+        {
+          actionType: 'roundCorners',
+          radius: [10, 20, 30, 40]
+        },
+        {
+          actionType: 'roundCorners',
+          radius: 'max'
+        }
+      ]
+    });
+  });
+});

--- a/__TESTS__/unit/toJson/roundCorners.toJson.test.ts
+++ b/__TESTS__/unit/toJson/roundCorners.toJson.test.ts
@@ -12,7 +12,7 @@ describe('RoundCorners toJson()', () => {
       actions: [
         {
           actionType: 'roundCorners',
-          radius: [10, undefined, undefined, undefined]
+          radius: [10]
         },
         {
           actionType: 'roundCorners',

--- a/src/actions/roundCorners/RoundCornersAction.ts
+++ b/src/actions/roundCorners/RoundCornersAction.ts
@@ -12,7 +12,7 @@ import {IActionModel} from "../../internal/models/IActionModel.js";
  */
 class RoundCornersAction extends Action {
   protected _actionModel: IRoundCornersActionModel = {};
-  private _radius: [number, number, number, number] | string;
+  private _radius: [number?, number?, number?, number?] | string;
 
   constructor() {
     super();
@@ -30,13 +30,14 @@ class RoundCornersAction extends Action {
     const qualifierValue = new QualifierValue();
 
     // In case a === 0, check typeof
-    typeof a !== undefined && qualifierValue.addValue(a);
-    typeof b !== undefined && qualifierValue.addValue(b);
-    typeof c !== undefined && qualifierValue.addValue(c);
-    typeof d !== undefined && qualifierValue.addValue(d);
+    a !== undefined && qualifierValue.addValue(a);
+    b !== undefined && qualifierValue.addValue(b);
+    c !== undefined && qualifierValue.addValue(c);
+    d !== undefined && qualifierValue.addValue(d);
 
-    this._radius = [a, b, c, d];
-    this._actionModel.radius = [a, b, c, d];
+    const definedRadiuses = ([a, b, c, d].filter((r) => r !== undefined) as [number?, number?, number?, number?]);
+    this._radius = definedRadiuses;
+    this._actionModel.radius = definedRadiuses;
 
     this.addQualifier(new Qualifier('r').addValue(qualifierValue));
     return this;

--- a/src/actions/roundCorners/RoundCornersAction.ts
+++ b/src/actions/roundCorners/RoundCornersAction.ts
@@ -12,7 +12,7 @@ import {IActionModel} from "../../internal/models/IActionModel.js";
  */
 class RoundCornersAction extends Action {
   protected _actionModel: IRoundCornersActionModel = {};
-  private _radius: [number?, number?, number?, number?] | string;
+  private _radius: [number?, number?, number?, number?] | 'max';
 
   constructor() {
     super();

--- a/src/actions/roundCorners/RoundCornersAction.ts
+++ b/src/actions/roundCorners/RoundCornersAction.ts
@@ -1,6 +1,8 @@
 import {Action} from "../../internal/Action.js";
 import {Qualifier} from "../../internal/qualifier/Qualifier.js";
 import {QualifierValue} from "../../internal/qualifier/QualifierValue.js";
+import {IRoundCornersActionModel} from "../../internal/models/IRoundCornersActionModel.js";
+import {IActionModel} from "../../internal/models/IActionModel.js";
 
 /**
  * @description A class to round one or more corners of an image or video.
@@ -9,8 +11,12 @@ import {QualifierValue} from "../../internal/qualifier/QualifierValue.js";
  * @see Visit {@link Actions.RoundCorners|RoundCorners} for an example
  */
 class RoundCornersAction extends Action {
+  protected _actionModel: IRoundCornersActionModel = {};
+  private _radius: [number, number, number, number] | string;
+
   constructor() {
     super();
+    this._actionModel.actionType = 'roundCorners';
   }
 
   /**
@@ -20,7 +26,7 @@ class RoundCornersAction extends Action {
    * @param {number} d
    * @return {RoundCornersAction}
    */
-  radius(a:number, b?:number, c?:number, d?:number):this {
+  radius(a: number, b?: number, c?: number, d?: number): this {
     const qualifierValue = new QualifierValue();
 
     // In case a === 0, check typeof
@@ -28,6 +34,9 @@ class RoundCornersAction extends Action {
     typeof b !== undefined && qualifierValue.addValue(b);
     typeof c !== undefined && qualifierValue.addValue(c);
     typeof d !== undefined && qualifierValue.addValue(d);
+
+    this._radius = [a, b, c, d];
+    this._actionModel.radius = [a, b, c, d];
 
     this.addQualifier(new Qualifier('r').addValue(qualifierValue));
     return this;
@@ -37,7 +46,26 @@ class RoundCornersAction extends Action {
    * @description Applies maximum rounding to the corners of the asset. An asset with square dimensions becomes a circle.
    */
   max(): this {
+    this._radius = 'max';
+    this._actionModel.radius = 'max';
+
     return this.addQualifier(new Qualifier('r', 'max'));
+  }
+
+  static fromJson(actionModel: IActionModel): RoundCornersAction {
+    const { radius } = (actionModel as IRoundCornersActionModel);
+
+    // We are using this() to allow inheriting classes to use super.fromJson.apply(this, [actionModel])
+    // This allows the inheriting classes to determine the class to be created
+    const result = new this();
+    if (Array.isArray(radius)) {
+      result.radius(radius[0], radius[1], radius[2], radius[3]);
+    }
+    if (radius === 'max') {
+      result.max();
+    }
+
+    return result;
   }
 }
 

--- a/src/actions/roundCorners/RoundCornersAction.ts
+++ b/src/actions/roundCorners/RoundCornersAction.ts
@@ -1,7 +1,7 @@
 import {Action} from "../../internal/Action.js";
 import {Qualifier} from "../../internal/qualifier/Qualifier.js";
 import {QualifierValue} from "../../internal/qualifier/QualifierValue.js";
-import {IRoundCornersActionModel} from "../../internal/models/IRoundCornersActionModel.js";
+import {IRoundCornersActionModel, CornerRadiusValueType} from "../../internal/models/IRoundCornersActionModel.js";
 import {IActionModel} from "../../internal/models/IActionModel.js";
 
 /**
@@ -12,7 +12,7 @@ import {IActionModel} from "../../internal/models/IActionModel.js";
  */
 class RoundCornersAction extends Action {
   protected _actionModel: IRoundCornersActionModel = {};
-  private _radius: [number?, number?, number?, number?] | 'max';
+  private _radius: CornerRadiusValueType;
 
   constructor() {
     super();
@@ -51,6 +51,10 @@ class RoundCornersAction extends Action {
     this._actionModel.radius = 'max';
 
     return this.addQualifier(new Qualifier('r', 'max'));
+  }
+
+  getRadius(): CornerRadiusValueType {
+    return this._radius;
   }
 
   static fromJson(actionModel: IActionModel): RoundCornersAction {

--- a/src/internal/fromJson.ts
+++ b/src/internal/fromJson.ts
@@ -62,6 +62,7 @@ import RotateAction from "../actions/rotate/RotateAction.js";
 import {BackgroundRemoval} from "../actions/effect/BackgroundRemoval.js";
 import {DropShadow} from "../actions/effect/DropShadow.js";
 import RoundCornersAction from "../actions/roundCorners/RoundCornersAction.js";
+import {BorderAction} from "../actions/border.js";
 
 const ActionModelMap: Record<string, IHasFromJson> = {
   scale: ResizeScaleAction,
@@ -135,6 +136,7 @@ const ActionModelMap: Record<string, IHasFromJson> = {
   backgroundRemoval: BackgroundRemoval,
   dropshadow: DropShadow,
   roundCorners: RoundCornersAction,
+  border: BorderAction,
 };
 
 /**

--- a/src/internal/fromJson.ts
+++ b/src/internal/fromJson.ts
@@ -61,6 +61,7 @@ import {ConditionalAction} from "../actions/conditional.js";
 import RotateAction from "../actions/rotate/RotateAction.js";
 import {BackgroundRemoval} from "../actions/effect/BackgroundRemoval.js";
 import {DropShadow} from "../actions/effect/DropShadow.js";
+import RoundCornersAction from "../actions/roundCorners/RoundCornersAction.js";
 
 const ActionModelMap: Record<string, IHasFromJson> = {
   scale: ResizeScaleAction,
@@ -133,6 +134,7 @@ const ActionModelMap: Record<string, IHasFromJson> = {
   rotateByAngle: RotateAction,
   backgroundRemoval: BackgroundRemoval,
   dropshadow: DropShadow,
+  roundCorners: RoundCornersAction,
 };
 
 /**

--- a/src/internal/models/IBorderActionModel.ts
+++ b/src/internal/models/IBorderActionModel.ts
@@ -1,0 +1,14 @@
+import {IActionModel} from "./IActionModel.js";
+import {CornerRadiusValueType} from "./IRoundCornersActionModel.js";
+
+interface IBorderActionModel extends IActionModel {
+  borderWidth?: number | string;
+  borderColor?: string;
+  borderType?: string;
+  roundCorners?: {
+    actionType: 'roundCorners';
+    radius: CornerRadiusValueType;
+  };
+}
+
+export {IBorderActionModel};

--- a/src/internal/models/IRoundCornersActionModel.ts
+++ b/src/internal/models/IRoundCornersActionModel.ts
@@ -1,7 +1,7 @@
 import {IActionModel} from "./IActionModel.js";
 
 interface IRoundCornersActionModel extends IActionModel {
-  radius?: [number?, number?, number?, number?] | string;
+  radius?: [number?, number?, number?, number?] | 'max';
 }
 
 export {IRoundCornersActionModel};

--- a/src/internal/models/IRoundCornersActionModel.ts
+++ b/src/internal/models/IRoundCornersActionModel.ts
@@ -1,7 +1,7 @@
 import {IActionModel} from "./IActionModel.js";
 
 interface IRoundCornersActionModel extends IActionModel {
-  radius?: [number, number, number, number] | string;
+  radius?: [number?, number?, number?, number?] | string;
 }
 
 export {IRoundCornersActionModel};

--- a/src/internal/models/IRoundCornersActionModel.ts
+++ b/src/internal/models/IRoundCornersActionModel.ts
@@ -1,7 +1,9 @@
 import {IActionModel} from "./IActionModel.js";
 
+type CornerRadiusValueType = [number?, number?, number?, number?] | 'max';
+
 interface IRoundCornersActionModel extends IActionModel {
-  radius?: [number?, number?, number?, number?] | 'max';
+  radius?: CornerRadiusValueType;
 }
 
-export {IRoundCornersActionModel};
+export {IRoundCornersActionModel, CornerRadiusValueType};

--- a/src/internal/models/IRoundCornersActionModel.ts
+++ b/src/internal/models/IRoundCornersActionModel.ts
@@ -1,0 +1,7 @@
+import {IActionModel} from "./IActionModel.js";
+
+interface IRoundCornersActionModel extends IActionModel {
+  radius?: [number, number, number, number] | string;
+}
+
+export {IRoundCornersActionModel};


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk

FYI there's a misalignment in the [transformation-model](https://github.com/CloudinaryLtd/transformation-model/blob/master/build/model/all.json#L6298), where we have two separated actions defined (`roundCorners` and `roundCornersMax`). 

I'm planning to merge them and model the `radius` property to reflect `[number?, number?, number?, number?] | 'max'` type. 

#### What does this PR solve?
- Add actionModel and fromJson/toJson support to the RoundCorners action


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
