### PR TITLE
Add missing focusOn export

### DIFF
--- a/src/qualifiers/autoFocus.ts
+++ b/src/qualifiers/autoFocus.ts
@@ -96,4 +96,8 @@ class AutoFocus extends QualifierValue {
   }
 }
 
-export {AutoFocus};
+const focusOn = (obj: FocusOnValue, weight?: number): AutoFocus => {
+  return new AutoFocus(obj, weight);
+};
+
+export {AutoFocus, focusOn};

--- a/src/qualifiers/autoFocus.ts
+++ b/src/qualifiers/autoFocus.ts
@@ -96,8 +96,6 @@ class AutoFocus extends QualifierValue {
   }
 }
 
-const focusOn = (obj: FocusOnValue, weight?: number): AutoFocus => {
-  return new AutoFocus(obj, weight);
-};
+const focusOn = AutoFocus.focusOn;
 
 export {AutoFocus, focusOn};


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Add missing named `onFocus` export in `autoFocus` qualifier

#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
