### PR TITLE
Return nested transformation errors at the layer action level

### DIFF
--- a/__TESTS__/unit/toJson/overlayUnderlay.toJson.test.ts
+++ b/__TESTS__/unit/toJson/overlayUnderlay.toJson.test.ts
@@ -18,6 +18,7 @@ import {BlendMode} from "../../../src/qualifiers/blendMode";
 import {TextStyle} from "../../../src/qualifiers/textStyle";
 import {FontAntialias} from "../../../src/qualifiers/FontAntialias";
 import {Underlay} from "../../../src/actions";
+import {UnsupportedError} from "../../../src/internal/utils/unsupportedError";
 
 describe('Overlay & Underlay toJson', () => {
   it('Should generate Overlay model for image source', () => {
@@ -261,5 +262,21 @@ describe('Overlay & Underlay toJson', () => {
         }
       ]
     });
+  });
+
+  it('Should return error when there is unsupported transformation inside', () => {
+    const transformation = new Transformation();
+    transformation.addAction(
+      Overlay.source(Source.image('sample').transformation(new Transformation()
+        .resize(scale(100).width(800))
+        .backgroundColor("red")
+      ))
+    );
+
+    expect(transformation.toJson()).toStrictEqual(
+      {
+        error: new UnsupportedError('unsupported action BackgroundColor')
+      }
+    );
   });
 });

--- a/src/internal/models/actionToJson.ts
+++ b/src/internal/models/actionToJson.ts
@@ -8,6 +8,12 @@ export type IActionToJson = IActionModel | IErrorObject;
  */
 export function actionToJson(): IActionToJson {
   const actionModelIsNotEmpty = this._actionModel && Object.keys(this._actionModel).length;
+  const sourceTransformationError = this._actionModel?.source?.transformation?.error;
+
+  // Should return error when there is unsupported transformation inside
+  if (sourceTransformationError && sourceTransformationError instanceof Error) {
+    return { error: sourceTransformationError };
+  }
 
   if (actionModelIsNotEmpty) {
     return this._actionModel;


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Adjusts `toJson` behaviour when it comes to unsupported nested transformations. Previously it could return
```
{"actionType":"overlay","source":{"publicId":"sample","sourceType":"image","transformation":{"error":{}}}}
```
So the error was "hidden" inside `source.transformation`. 
After the changes, the error will be returned instead of action data object. 

#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
