### PR TITLE
Default value for background removal's fine edges option

### DIFF
--- a/__TESTS__/unit/toJson/backgroundRemoval.toJson.test.ts
+++ b/__TESTS__/unit/toJson/backgroundRemoval.toJson.test.ts
@@ -16,4 +16,39 @@ describe('BackgroundRemoval toJson()', () => {
       ]
     });
   });
+  it('with default fineEdges', () => {
+    const transformation = new Transformation()
+      .addAction(Effect.backgroundRemoval().fineEdges());
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'backgroundRemoval',
+          fineEdges: true,
+        }
+      ]
+    });
+  });
+  it('with false fineEdges', () => {
+    const transformation = new Transformation()
+      .addAction(Effect.backgroundRemoval().fineEdges(false));
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'backgroundRemoval',
+          fineEdges: false,
+        }
+      ]
+    });
+  });
+  it('without fineEdges', () => {
+    const transformation = new Transformation()
+      .addAction(Effect.backgroundRemoval());
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'backgroundRemoval',
+        }
+      ]
+    });
+  });
 });

--- a/src/actions/effect/BackgroundRemoval.ts
+++ b/src/actions/effect/BackgroundRemoval.ts
@@ -20,12 +20,9 @@ class BackgroundRemoval extends Action {
     this._actionModel.actionType = 'backgroundRemoval';
   }
 
-  fineEdges(value: boolean) {
+  fineEdges(value = true) {
     this._fineEdges = value;
-
-    if (this._fineEdges) {
-      this._actionModel.fineEdges = this._fineEdges;
-    }
+    this._actionModel.fineEdges = this._fineEdges;
     return this;
   }
 
@@ -54,10 +51,14 @@ class BackgroundRemoval extends Action {
 
   static fromJson(actionModel: IActionModel): BackgroundRemoval {
     const {fineEdges, hints} = (actionModel as IBackgroundRemovalModel);
+    const result = new this();
 
-    // We are using this() to allow inheriting classes to use super.fromJson.apply(this, [actionModel])
-    // This allows the inheriting classes to determine the class to be created
-    return new this().fineEdges(fineEdges).hints(hints);
+    if (fineEdges !== undefined) {
+      result.fineEdges(fineEdges);
+    }
+    result.hints(hints);
+
+    return result;
   }
 }
 


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Default value for background removal's fine edges option.

Before:
```ts
backgroundRemoval().fineEdges(true) // fineEdges: true
backgroundRemoval().fineEdges() // fineEdges: undefined
backgroundRemoval().fineEdges(false) // fineEdges: undefined
backgroundRemoval() // fineEdges: undefined
```

After changes:
```ts
backgroundRemoval().fineEdges(true) // fineEdges: true
backgroundRemoval().fineEdges() // fineEdges: true
backgroundRemoval().fineEdges(false) // fineEdges: false
backgroundRemoval() // fineEdges: undefined
```

#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
