### PR TITLE
Fix: Sync BackgroundRemoval hints with autogenerated docs examples

### DIFF
--- a/__TESTS__/unit/toJson/backgroundRemoval.toJson.test.ts
+++ b/__TESTS__/unit/toJson/backgroundRemoval.toJson.test.ts
@@ -1,5 +1,5 @@
 import {Transformation} from "../../../src";
-import {ForegroundObject} from "../../../src/qualifiers/foregroundObject";
+import {ForegroundObject, cat, bus, diningTable} from "../../../src/qualifiers/foregroundObject";
 import {Effect} from "../../../src/actions/effect";
 
 describe('BackgroundRemoval toJson()', () => {
@@ -12,6 +12,19 @@ describe('BackgroundRemoval toJson()', () => {
           actionType: 'backgroundRemoval',
           fineEdges: true,
           hints: [ForegroundObject.CAT, ForegroundObject.DOG]
+        }
+      ]
+    });
+  });
+  it('with functional hints as spread arg', () => {
+    const transformation = new Transformation()
+      .addAction(Effect.backgroundRemoval().fineEdges(true).hints(cat(), bus(), diningTable()));
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'backgroundRemoval',
+          fineEdges: true,
+          hints: [ForegroundObject.CAT, ForegroundObject.BUS, ForegroundObject.DINING_TABLE]
         }
       ]
     });

--- a/src/actions/effect/BackgroundRemoval.ts
+++ b/src/actions/effect/BackgroundRemoval.ts
@@ -30,7 +30,7 @@ class BackgroundRemoval extends Action {
     if (values.length === 1 && Array.isArray(values[0])) {
       // Handle the case of a single array argument
       this._hints = values[0];
-    } else {
+    } else if (values.length) {
       this._hints = values as ForegroundObjectValue[];
     }
 
@@ -61,7 +61,9 @@ class BackgroundRemoval extends Action {
     if (fineEdges !== undefined) {
       result.fineEdges(fineEdges);
     }
-    result.hints(hints);
+    if (hints?.length) {
+      result.hints(hints);
+    }
 
     return result;
   }

--- a/src/actions/effect/BackgroundRemoval.ts
+++ b/src/actions/effect/BackgroundRemoval.ts
@@ -26,8 +26,13 @@ class BackgroundRemoval extends Action {
     return this;
   }
 
-  hints(value: Array<ForegroundObjectValue>) {
-    this._hints = value;
+  hints(...values: ForegroundObjectValue[] | [ForegroundObjectValue[]]) {
+    if (values.length === 1 && Array.isArray(values[0])) {
+      // Handle the case of a single array argument
+      this._hints = values[0];
+    } else {
+      this._hints = values as ForegroundObjectValue[];
+    }
 
     if (this._hints) {
       this._actionModel.hints = this._hints;

--- a/src/qualifiers/foregroundObject.ts
+++ b/src/qualifiers/foregroundObject.ts
@@ -31,3 +31,163 @@ const ForegroundObject = {
 
 export {ForegroundObject};
 export type ForegroundObjectValue = typeof ForegroundObject[keyof typeof ForegroundObject];
+
+/**
+ * @summary qualifier
+ * @description Foreground object "airplane".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const airplane = (): ForegroundObjectValue => ForegroundObject.AIRPLANE;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "bus".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const bus = (): ForegroundObjectValue => ForegroundObject.BUS;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "dining_table".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const diningTable = (): ForegroundObjectValue => ForegroundObject.DINING_TABLE;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "sheep".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const sheep = (): ForegroundObjectValue => ForegroundObject.SHEEP;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "bicycle".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const bicycle = (): ForegroundObjectValue => ForegroundObject.BICYCLE;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "car".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const car = (): ForegroundObjectValue => ForegroundObject.CAR;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "dog".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const dog = (): ForegroundObjectValue => ForegroundObject.DOG;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "sofa".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const sofa = (): ForegroundObjectValue => ForegroundObject.SOFA;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "bird".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const bird = (): ForegroundObjectValue => ForegroundObject.BIRD;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "cat".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const cat = (): ForegroundObjectValue => ForegroundObject.CAT;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "horse".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const horse = (): ForegroundObjectValue => ForegroundObject.HORSE;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "train".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const train = (): ForegroundObjectValue => ForegroundObject.TRAIN;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "boat".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const boat = (): ForegroundObjectValue => ForegroundObject.BOAT;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "chair".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const chair = (): ForegroundObjectValue => ForegroundObject.CHAIR;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "person".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const person = (): ForegroundObjectValue => ForegroundObject.PERSON;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "tv".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const tv = (): ForegroundObjectValue => ForegroundObject.TV;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "bottle".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const bottle = (): ForegroundObjectValue => ForegroundObject.BOTTLE;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "cow".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const cow = (): ForegroundObjectValue => ForegroundObject.COW;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "potted_plant".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const pottedPlant = (): ForegroundObjectValue => ForegroundObject.POTTED_PLANT;
+
+/**
+ * @summary qualifier
+ * @description Foreground object "motorbike".
+ * @memberOf Qualifiers.ForegroundObject
+ * @return {Qualifiers.ForegroundObject}
+ */
+export const motorbike = (): ForegroundObjectValue => ForegroundObject.MOTORBIKE;


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
`ForegroundObject` qualifier (used in Background Removal `hints`) was inconsistent with autogenerated code snippet for this action:

```
import { backgroundRemoval } from "@cloudinary/url-gen/actions/effect";
import { cat, dog, bicycle } from "@cloudinary/url-gen/qualifiers/foregroundObject";

new CloudinaryImage("docs/rmv_bgd/side_cat_dog_orig.png").effect(
  backgroundRemoval().hints(cat(), dog(), bicycle())
);
```

This fix keeps backward compatibility with the previous SDK implementation _(to not create breaking changes and still handle `hints([ForegroundObject.CAT, ForegroundObject.DOG])`)_, but adds handling for the common syntax presented in the Cloudinary Docs. 


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
