### PR TITLE
Add support for Generative Fill background

### DIFF
--- a/__TESTS__/unit/actions/Background.test.ts
+++ b/__TESTS__/unit/actions/Background.test.ts
@@ -150,4 +150,25 @@ describe('Tests for Transformation Action -- Background', () => {
 
     expect(tx).toContain('b_blurred:100:100');
   });
+
+  describe('Test generative fill background', () => {
+    it('without prompt', () => {
+      const tx = new Transformation()
+        .resize(Resize.pad(250, 250)
+          .background("gen_fill")
+        )
+        .toString();
+
+      expect(tx).toContain('b_gen_fill');
+    });
+    it('with prompt', () => {
+      const tx = new Transformation()
+        .resize(Resize.pad(250, 250)
+          .background("gen_fill:prompt_turtles in the sea")
+        )
+        .toString();
+
+      expect(tx).toContain('b_gen_fill:prompt_turtles in the sea');
+    });
+  });
 });

--- a/__TESTS__/unit/fromJson/resize.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/resize.fromJson.test.ts
@@ -43,6 +43,21 @@ describe('resize.fromJson', () => {
             ]
           }
         }
+      },
+      {
+        actionType: 'pad',
+        dimensions: {width: 200},
+        background: {
+          backgroundType: 'generativeFill',
+          prompt: 'hello'
+        }
+      },
+      {
+        actionType: 'minimumPad',
+        dimensions: {width: 200, aspectRatio: 7},
+        background: {
+          backgroundType: 'generativeFill'
+        }
       }
     ]});
 
@@ -60,6 +75,8 @@ describe('resize.fromJson', () => {
       'b_white,c_mpad,fl_relative,g_south,w_100,x_3,y_4',
       'c_crop,g_auto:person_100:cat_avoid,w_200',
       'c_crop,g_dog:auto:bird_30:cat_avoid,w_200',
+      'b_gen_fill:prompt_hello,c_pad,w_200',
+      'ar_7.0,b_gen_fill,c_mpad,w_200'
     ].join('/'));
   });
 

--- a/__TESTS__/unit/toJson/resize.toJson.test.ts
+++ b/__TESTS__/unit/toJson/resize.toJson.test.ts
@@ -445,4 +445,36 @@ describe('resize.toJson()', () => {
       ]
     });
   });
+
+  it('should generate a Generative Fill background', () => {
+    const transformation = new Transformation()
+      .addAction(Resize.pad(400).background('gen_fill'))
+      .addAction(Resize.pad(200).background('gen_fill:prompt_strawberry donuts'));
+
+    const model = transformation.toJson();
+
+    expect(model).toStrictEqual({
+      actions: [
+        {
+          actionType: 'pad',
+          dimensions: {
+            width: 400
+          },
+          background: {
+            backgroundType: 'generativeFill'
+          }
+        },
+        {
+          actionType: 'pad',
+          dimensions: {
+            width: 200
+          },
+          background: {
+            backgroundType: 'generativeFill',
+            prompt: 'strawberry donuts'
+          }
+        },
+      ]
+    });
+  });
 });

--- a/src/actions/resize/ResizePadAction.ts
+++ b/src/actions/resize/ResizePadAction.ts
@@ -19,8 +19,12 @@ class ResizePadAction<GravityType extends IGravity> extends ResizeAdvancedAction
    * @param {Qualifiers.Background} backgroundQualifier Defines the background color to use instead of
    * transparent background areas or when resizing with padding.
    */
-  background(backgroundQualifier: BackgroundQualifier): this {
+  background(backgroundQualifier: BackgroundQualifier | string): this {
     this._actionModel.background = createBackgroundModel(backgroundQualifier);
+
+    if (typeof backgroundQualifier === 'string' && backgroundQualifier.startsWith('gen_fill')) {
+      return this.addQualifier(new Qualifier('b', backgroundQualifier));
+    }
     return this.addQualifier(backgroundQualifier);
   }
 

--- a/src/internal/models/createBackgroundFromModel.ts
+++ b/src/internal/models/createBackgroundFromModel.ts
@@ -5,6 +5,7 @@ import {
   IBorderBackgroundModel,
   IBorderGradientBackgroundModel,
   IColorBackgroundModel,
+  IGenerativeFillBackgroundModel,
   IPredominantBackgroundModel,
   IPredominantGradientBackgroundModel
 } from "./createBackgroundModel.js";
@@ -12,6 +13,7 @@ import {Background} from "../../qualifiers.js";
 import {BackgroundBorderGradientQualifier} from "../../qualifiers/background/shared/gradient/BackgroundBorderGradientQualifier.js";
 import {auto, border, borderGradient, color, predominant, predominantGradient} from "../../qualifiers/background.js";
 import {BackgroundAutoPredominantQualifier} from "../../qualifiers/background/shared/auto/BackgroundAutoPredominantQualifier.js";
+import {Qualifier} from "../qualifier/Qualifier.js";
 
 /**
  * Create BackgroundQualifier from IBlurredBackgroundModel
@@ -79,6 +81,14 @@ function createContrastPaletteBackground(background: BackgroundAutoPredominantQu
 }
 
 /**
+ * Create a Generative Fill background from given model
+ * @param backgroundModel
+ */
+function createGenerativeFillBackground(backgroundModel: IGenerativeFillBackgroundModel) {
+  return new Qualifier('b', `gen_fill${backgroundModel.prompt ? `:prompt_${backgroundModel.prompt}` : ''}`);
+}
+
+/**
  * Create BackgroundQualifier from IBackgroundModel
  * @param backgroundModel
  */
@@ -98,6 +108,8 @@ function createBackgroundFromModel(backgroundModel: IBackgroundModel): Backgroun
       return createContrastPaletteBackground(predominant(), backgroundModel as IPredominantBackgroundModel);
     case 'predominantGradient':
       return createGradientBackground(predominantGradient(), backgroundModel as IPredominantGradientBackgroundModel);
+    case 'generativeFill':
+      return createGenerativeFillBackground(backgroundModel as IGenerativeFillBackgroundModel);
     default:
       return color((backgroundModel as IColorBackgroundModel).color);
   }

--- a/src/internal/models/createBackgroundModel.ts
+++ b/src/internal/models/createBackgroundModel.ts
@@ -54,6 +54,11 @@ interface IPredominantGradientBackgroundModel extends IBaseGradientBackgroundMod
   backgroundType: 'predominantGradient';
 }
 
+interface IGenerativeFillBackgroundModel {
+  backgroundType: 'generativeFill';
+  prompt?: string;
+}
+
 /**
  * Get the value of given background
  * @param background
@@ -193,6 +198,18 @@ function createPredominantGradientBackgroundModel(background: BackgroundPredomin
 }
 
 /**
+ * Create an IGenerativeFillBackgroundModel from given background
+ * @param urlValue
+ */
+function createGenerativeFillBackgroundModel(urlValue: string): IGenerativeFillBackgroundModel {
+  const prompt = urlValue.split(':prompt_')[1];
+  return {
+    backgroundType: "generativeFill",
+    ...(prompt ? { prompt } : {})
+  };
+}
+
+/**
  * Create an IBackgroundModel from given background
  * @param background
  */
@@ -221,6 +238,10 @@ function createBackgroundModel(background: unknown): IBackgroundModel {
     return createPredominantGradientBackgroundModel(background);
   }
 
+  if (getBackgroundValue(background).startsWith('gen_fill')) {
+    return createGenerativeFillBackgroundModel(getBackgroundValue(background));
+  }
+
   return createColorBackgroundModel(background as BackgroundColor);
 }
 
@@ -233,5 +254,6 @@ export {
   IColorBackgroundModel,
   IPredominantBackgroundModel,
   IPredominantGradientBackgroundModel,
+  IGenerativeFillBackgroundModel,
   createBackgroundModel
 };


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?

This PR adds handling of `gen_fill` background option in a way it is stated in the Cloudinary documentation:  

```
new CloudinaryImage("docs/food.jpg").resize(
  pad()
    .width(1000)
    .height(1800)
    .gravity(compass("south"))
    .background("gen_fill:prompt_bowls of cereal")
);
```


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
