### PR TITLE
simplify API of GenerativeRemove

### DIFF
--- a/__TESTS__/unit/toJson/generativeRemove.toJson.test.ts
+++ b/__TESTS__/unit/toJson/generativeRemove.toJson.test.ts
@@ -1,6 +1,7 @@
 import { Transformation } from "../../../src";
 import { Effect } from "../../../src/actions/effect";
 import { GenerativeRemove } from "../../../src/actions/effect/GenerativeRemove";
+import { Region } from "../../../src/qualifiers/region";
 
 describe("GenerativeRemove.toJson()", () => {
   it("produces correct action JSON", () => {
@@ -18,31 +19,28 @@ describe("GenerativeRemove.toJson()", () => {
         },
       ],
       [
-        Effect.generativeRemove().prompts(["dog", "cat"]),
+        Effect.generativeRemove().prompt("dog", "cat"),
         { actionType: "generativeRemove", prompts: ["dog", "cat"] },
       ],
       [
-        Effect.generativeRemove().region({
-          x: 100,
-          y: 200,
-          width: 600,
-          height: 400,
-        }),
-        {
-          actionType: "generativeRemove",
-          regions: [{ x: 100, y: 200, width: 600, height: 400 }],
-        },
-      ],
-      [
-        Effect.generativeRemove().regions([
-          { x: 100, y: 200, width: 600, height: 400 },
-          { x: 300, y: 400, width: 50, height: 60 },
-        ]),
+        Effect.generativeRemove().region(Region.rectangle(50, 60, 600, 400)),
         {
           actionType: "generativeRemove",
           regions: [
-            { x: 100, y: 200, width: 600, height: 400 },
-            { x: 300, y: 400, width: 50, height: 60 },
+            { regionType: "rectangle", x: 50, y: 60, width: 600, height: 400 },
+          ],
+        },
+      ],
+      [
+        Effect.generativeRemove().region(
+          Region.rectangle(10, 20, 600, 400),
+          Region.rectangle(300, 400, 50, 60)
+        ),
+        {
+          actionType: "generativeRemove",
+          regions: [
+            { regionType: "rectangle", x: 10, y: 20, width: 600, height: 400 },
+            { regionType: "rectangle", x: 300, y: 400, width: 50, height: 60 },
           ],
         },
       ],

--- a/src/qualifiers/region.ts
+++ b/src/qualifiers/region.ts
@@ -1,5 +1,6 @@
-import {CustomRegion} from "./region/CustomRegion.js";
-import {NamedRegion} from "./region/NamedRegion.js";
+import { CustomRegion } from "./region/CustomRegion.js";
+import { NamedRegion } from "./region/NamedRegion.js";
+import { RectangleRegion } from "./region/RectangleRegion.js";
 
 /**
  * @summary qualifier
@@ -16,7 +17,7 @@ function custom(): CustomRegion {
  * @return {Qualifiers.Region.NamedRegion}
  */
 function faces(): NamedRegion {
-  return new NamedRegion('faces');
+  return new NamedRegion("faces");
 }
 
 /**
@@ -25,7 +26,21 @@ function faces(): NamedRegion {
  * @return {Qualifiers.Region.NamedRegion}
  */
 function ocr(): NamedRegion {
-  return new NamedRegion('ocr_text');
+  return new NamedRegion("ocr_text");
+}
+
+/**
+ * @summary qualifier
+ * @memberOf Qualifiers.Region
+ * @return {Qualifiers.Region.NamedRegion}
+ */
+function rectangle(
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): NamedRegion {
+  return new RectangleRegion(x, y, width, height);
 }
 
 /**
@@ -36,5 +51,5 @@ function ocr(): NamedRegion {
  * @namespace Region
  * @memberOf Qualifiers
  */
-const Region = { ocr, faces, custom };
-export {Region, ocr, faces, custom};
+const Region = { ocr, faces, custom, rectangle };
+export { Region, ocr, faces, custom, rectangle };

--- a/src/qualifiers/region/NamedRegion.ts
+++ b/src/qualifiers/region/NamedRegion.ts
@@ -1,16 +1,17 @@
-import {Action} from "../../internal/Action.js";
+import { Action } from "../../internal/Action.js";
+
+type RegionType = "faces" | "ocr_text" | "named" | "rectangle";
 
 /**
  * @memberOf Qualifiers.Region
  */
 class NamedRegion extends Action {
-  public regionType: 'faces' | 'ocr_text' | 'named';
+  public regionType: RegionType;
 
-  constructor(type: 'faces' | 'ocr_text' | 'named') {
+  constructor(type: RegionType) {
     super();
     this.regionType = type;
   }
 }
 
-
-export {NamedRegion};
+export { NamedRegion, RegionType };

--- a/src/qualifiers/region/RectangleRegion.ts
+++ b/src/qualifiers/region/RectangleRegion.ts
@@ -1,0 +1,40 @@
+import { NamedRegion } from "./NamedRegion.js";
+import { Qualifier } from "../../internal/qualifier/Qualifier.js";
+
+/**
+ * @memberOf Qualifiers.Region
+ */
+class RectangleRegion extends NamedRegion {
+  /**
+   * Rectangle defines a region where action will be applied
+   *
+   * @param {number} x The x position in pixels
+   * @param {number} y The y position in pixels
+   * @param {number} width The width in pixels
+   * @param {number} height The height in pixels
+   */
+  constructor(x: number, y: number, width: number, height: number) {
+    super("rectangle");
+
+    this.addQualifier(new Qualifier("x", x));
+    this.addQualifier(new Qualifier("y", y));
+    this.addQualifier(new Qualifier("w", width));
+    this.addQualifier(new Qualifier("h", height));
+
+    this._actionModel = {
+      x,
+      y,
+      width,
+      height,
+      regionType: this.regionType,
+    };
+  }
+
+  toString(): string {
+    const { x, y, width, height } = this._actionModel;
+
+    return `(x_${x};y_${y};w_${width};h_${height})`;
+  }
+}
+
+export { RectangleRegion };


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
Simplify API of `GenerativeRemove` effect. Methods `prompts` and `regions` are replaced by `prompt` and `region` that now support array values. Moreover, new qualifier `Region.rectangle`.

```js
// before
Effect.generativeRemove().prompts(["dog", "cat"]) 
// after
Effect.generativeRemove().prompt("dog", "cat")

// before
Effect.generativeRemove().regions([{x: 100, y: 100, width: 400, height: 400}, {...}]) 
// after
Effect.generativeRemove().region(Region.rectangle(100, 100, 400, 400), Region.rectangle(...)) 
```


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
