### PR TITLE
Generative Recolor color formatting fix

### DIFF
--- a/__TESTS__/unit/actions/Effect.test.ts
+++ b/__TESTS__/unit/actions/Effect.test.ts
@@ -344,7 +344,8 @@ describe('Tests for Transformation Action -- Effect', () => {
 
   it('Test generativeRecolor', () => {
     expect(Effect.generativeRecolor('prompt1', 'red').toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red');
-    expect(Effect.generativeRecolor('prompt1', 'red').multiple(true).toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red;multiple_true');
+    expect(Effect.generativeRecolor('prompt1', '#fff').toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_fff');
+    expect(Effect.generativeRecolor('prompt1', 'red').multiple(true).toString()).toBe('e_gen_recolor:prompt_prompt1;multiple_true;to-color_red');
     expect(Effect.generativeRecolor('prompt1', 'red').multiple(false).toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red');
     expect(Effect.generativeRecolor(['prompt1', 'prompt2'], 'red').toString()).toBe('e_gen_recolor:prompt_(prompt1;prompt2);to-color_red');
     expect(Effect.generativeRecolor(['prompt1', 'prompt2'], 'red').multiple(false).toString()).toBe('e_gen_recolor:prompt_(prompt1;prompt2);to-color_red');

--- a/__TESTS__/unit/fromJson/effect.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/effect.fromJson.test.ts
@@ -80,7 +80,7 @@ describe('effect.fromJson', () => {
       'e_dropshadow:azimuth_20',
       'e_dropshadow:azimuth_60;elevation_20;spread_30',
       'e_gen_replace:from_sunny sky;to_dark sky;preserve-geometry_true',
-      'e_gen_recolor:prompt_something;to-color_red;multiple_true',
+      'e_gen_recolor:prompt_something;multiple_true;to-color_red',
       'e_gen_recolor:prompt_(something;else);to-color_blue',
     ].join('/'));
   });

--- a/src/actions/effect.ts
+++ b/src/actions/effect.ts
@@ -465,11 +465,11 @@ function generativeReplace(): GenerativeReplace {
  * @description Uses generative AI to recolor objects from your image.
  *              {@link https://cloudinary.com/documentation/transformation_reference#e_gen_recolor|Generative Recolor}
  * @param {string | string[]} prompts
- * @param {SystemColors | string} color
+ * @param {SystemColors} color
  * @memberOf Actions.Effect
  * @return {Actions.Effect.GenerativeRecolor}
  */
-function generativeRecolor(prompts: string | string[], color: SystemColors | string): GenerativeRecolor {
+function generativeRecolor(prompts: string | string[], color: SystemColors): GenerativeRecolor {
   return new GenerativeRecolor(prompts, color);
 }
 

--- a/src/actions/effect/GenerativeRecolor.ts
+++ b/src/actions/effect/GenerativeRecolor.ts
@@ -13,9 +13,9 @@ import {SystemColors} from "../../qualifiers/color.js";
 class GenerativeRecolor extends Action {
   private _prompts: Array<string> = [];
   private _detectMultiple = false;
-  private _toColor: SystemColors | string;
+  private _toColor: SystemColors;
 
-  constructor(prompts: string | string[], color: SystemColors | string) {
+  constructor(prompts: string | string[], color: SystemColors) {
     super();
 
     this._prompts = Array.isArray(prompts) ? prompts : [prompts];
@@ -42,6 +42,10 @@ class GenerativeRecolor extends Action {
     if (this._prompts.length) {
       qualifierValue.addValue(this.preparePromptValue());
     }
+    if (this._toColor) {
+      const formattedColor = this._toColor.match(/^#/) ? this._toColor.substr(1) : this._toColor;
+      qualifierValue.addValue(`to-color_${formattedColor}`);
+    }
 
     this.addQualifier(
       new Qualifier("e", `gen_recolor:${qualifierValue.toString()}`)
@@ -51,25 +55,17 @@ class GenerativeRecolor extends Action {
   private preparePromptValue() {
     const prompts = this._prompts;
     const detectMultiple = this._detectMultiple;
-    const toColor = this._toColor;
 
     const qualifierValue = new QualifierValue().setDelimiter(";");
 
     if (prompts.length === 1) {
       qualifierValue.addValue(`prompt_${prompts[0]}`);
 
-      if (toColor) {
-        qualifierValue.addValue(`to-color_${toColor}`);
-      }
       if (detectMultiple) {
         qualifierValue.addValue("multiple_true");
       }
     } else {
       qualifierValue.addValue(`prompt_(${prompts.join(";")})`);
-
-      if (toColor) {
-        qualifierValue.addValue(`to-color_${toColor}`);
-      }
     }
 
     return qualifierValue;


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Fix Generative Recolor `color` formatting when `#hex` is provided  


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
