### PR TITLE
Fixes parameters delimiter in BackgroundRemoval action

### DIFF
--- a/__TESTS__/unit/fromJson/backgroundRemoval.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/backgroundRemoval.fromJson.test.ts
@@ -1,24 +1,37 @@
-import {fromJson} from "../../../src/internal/fromJson";
-import {ForegroundObject} from "../../../src/qualifiers/foregroundObject";
+import { fromJson } from "../../../src/internal/fromJson";
+import { ForegroundObject } from "../../../src/qualifiers/foregroundObject";
 
-describe('backgroundRemoval.fromJson', () => {
-  it('should generate a url with backgroundRemoval', function () {
-    const transformation = fromJson({actions:[
-      { actionType: 'backgroundRemoval'},
-      { actionType: 'backgroundRemoval', fineEdges: true},
-      { actionType: 'backgroundRemoval', fineEdges: false},
-      { actionType: 'backgroundRemoval', hints: []},
-      { actionType: 'backgroundRemoval', hints: [ForegroundObject.DOG, ForegroundObject.CAT]},
-      { actionType: 'backgroundRemoval', fineEdges: true, hints: [ForegroundObject.DOG, ForegroundObject.CAT]},
-    ]});
+describe("backgroundRemoval.fromJson", () => {
+  it("should generate a url with backgroundRemoval", function () {
+    const transformation = fromJson({
+      actions: [
+        { actionType: "backgroundRemoval" },
+        { actionType: "backgroundRemoval", fineEdges: true },
+        { actionType: "backgroundRemoval", fineEdges: false },
+        { actionType: "backgroundRemoval", hints: [] },
+        { actionType: "backgroundRemoval", hints: [ForegroundObject.DOG] },
+        {
+          actionType: "backgroundRemoval",
+          hints: [ForegroundObject.DOG, ForegroundObject.CAT],
+        },
+        {
+          actionType: "backgroundRemoval",
+          fineEdges: true,
+          hints: [ForegroundObject.DOG, ForegroundObject.CAT],
+        },
+      ],
+    });
 
-    expect(transformation.toString()).toStrictEqual([
-      'e_background_removal',
-      'e_background_removal:fineedges_y',
-      'e_background_removal:fineedges_n',
-      'e_background_removal',
-      'e_background_removal:hints_(dog;cat)',
-      'e_background_removal:fineedges_y:hints_(dog;cat)',
-    ].join('/'));
+    expect(transformation.toString()).toStrictEqual(
+      [
+        "e_background_removal",
+        "e_background_removal:fineedges_y",
+        "e_background_removal:fineedges_n",
+        "e_background_removal",
+        "e_background_removal:hints_(dog)",
+        "e_background_removal:hints_(dog;cat)",
+        "e_background_removal:fineedges_y;hints_(dog;cat)",
+      ].join("/")
+    );
   });
 });

--- a/src/actions/effect/BackgroundRemoval.ts
+++ b/src/actions/effect/BackgroundRemoval.ts
@@ -1,9 +1,9 @@
-import {Action} from "../../internal/Action.js";
-import {QualifierValue} from "../../internal/qualifier/QualifierValue.js";
-import {Qualifier} from "../../internal/qualifier/Qualifier.js";
-import {ForegroundObjectValue} from "../../qualifiers/foregroundObject.js";
-import {IActionModel} from "../../internal/models/IActionModel.js";
-import {IBackgroundRemovalModel} from "../../internal/models/IEffectActionModel.js";
+import { Action } from "../../internal/Action.js";
+import { QualifierValue } from "../../internal/qualifier/QualifierValue.js";
+import { Qualifier } from "../../internal/qualifier/Qualifier.js";
+import { ForegroundObjectValue } from "../../qualifiers/foregroundObject.js";
+import { IActionModel } from "../../internal/models/IActionModel.js";
+import { IBackgroundRemovalModel } from "../../internal/models/IEffectActionModel.js";
 
 /**
  * @description A class that defines how to remove the background of an asset
@@ -17,7 +17,7 @@ class BackgroundRemoval extends Action {
 
   constructor() {
     super();
-    this._actionModel.actionType = 'backgroundRemoval';
+    this._actionModel.actionType = "backgroundRemoval";
   }
 
   fineEdges(value = true) {
@@ -41,21 +41,33 @@ class BackgroundRemoval extends Action {
   }
 
   protected prepareQualifiers(): void {
-    let str = 'background_removal';
+    let str = "background_removal";
+
+    const params: string[] = [];
 
     if (this._fineEdges !== undefined) {
-      str += `:${new QualifierValue(`fineedges_${this._fineEdges ? 'y' : 'n'}`).toString()}`;
+      params.push(
+        new QualifierValue(
+          `fineedges_${this._fineEdges ? "y" : "n"}`
+        ).toString()
+      );
     }
 
     if (this._hints?.length) {
-      str += `:${new QualifierValue(`hints_(${this._hints.join(';')})`).toString()}`;
+      params.push(
+        new QualifierValue(`hints_(${this._hints.join(";")})`).toString()
+      );
     }
 
-    this.addQualifier(new Qualifier('e', str));
+    if (params.length > 0) {
+      str += `:${params.join(";")}`;
+    }
+
+    this.addQualifier(new Qualifier("e", str));
   }
 
   static fromJson(actionModel: IActionModel): BackgroundRemoval {
-    const {fineEdges, hints} = (actionModel as IBackgroundRemovalModel);
+    const { fineEdges, hints } = actionModel as IBackgroundRemovalModel;
     const result = new this();
 
     if (fineEdges !== undefined) {
@@ -69,5 +81,4 @@ class BackgroundRemoval extends Action {
   }
 }
 
-
-export {BackgroundRemoval};
+export { BackgroundRemoval };


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
Splits parameters of `BackgroundRemoval` with `;` instead of `:`.


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
