### PR TITLE
Add missing parameters to generative actions

### DIFF
--- a/__TESTS__/unit/actions/Effect.test.ts
+++ b/__TESTS__/unit/actions/Effect.test.ts
@@ -346,10 +346,12 @@ describe('Tests for Transformation Action -- Effect', () => {
   it('Test generativeRecolor', () => {
     expect(Effect.generativeRecolor('prompt1', 'red').toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red');
     expect(Effect.generativeRecolor('prompt1', '#fff').toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_fff');
-    expect(Effect.generativeRecolor('prompt1', 'red').multiple(true).toString()).toBe('e_gen_recolor:prompt_prompt1;multiple_true;to-color_red');
+    expect(Effect.generativeRecolor('prompt1', 'red').multiple(true).toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red;multiple_true');
     expect(Effect.generativeRecolor('prompt1', 'red').multiple(false).toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red');
+    expect(Effect.generativeRecolor('prompt1', 'red').detectMultiple(true).toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red;multiple_true');
+    expect(Effect.generativeRecolor('prompt1', 'red').detectMultiple(false).toString()).toBe('e_gen_recolor:prompt_prompt1;to-color_red');
     expect(Effect.generativeRecolor(['prompt1', 'prompt2'], 'red').toString()).toBe('e_gen_recolor:prompt_(prompt1;prompt2);to-color_red');
-    expect(Effect.generativeRecolor(['prompt1', 'prompt2'], 'red').multiple(false).toString()).toBe('e_gen_recolor:prompt_(prompt1;prompt2);to-color_red');
+    expect(Effect.generativeRecolor(['prompt1', 'prompt2'], 'red').detectMultiple(false).toString()).toBe('e_gen_recolor:prompt_(prompt1;prompt2);to-color_red');
   });
 
   it('Test theme effect', () => {

--- a/__TESTS__/unit/fromJson/effect.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/effect.fromJson.test.ts
@@ -39,6 +39,8 @@ describe('effect.fromJson', () => {
       { actionType: 'dropshadow', azimuth: 20 },
       { actionType: 'dropshadow', spread: 30, elevation: 20, azimuth: 60 },
       { actionType: 'generativeReplace', from: 'sunny sky', to: 'dark sky', preserveGeometry: true },
+      { actionType: 'generativeReplace', from: 'sunny sky', to: 'dark sky', detectMultiple: true },
+      { actionType: 'generativeReplace', from: 'sunny sky', to: 'dark sky', preserveGeometry: true, detectMultiple: true },
       { actionType: 'generativeRecolor', prompts: ['something'], toColor: 'red', detectMultiple: true },
       { actionType: 'generativeRecolor', prompts: ['something', 'else'], toColor: 'blue', detectMultiple: false },
       { actionType: 'generativeRestore' }
@@ -81,7 +83,9 @@ describe('effect.fromJson', () => {
       'e_dropshadow:azimuth_20',
       'e_dropshadow:azimuth_60;elevation_20;spread_30',
       'e_gen_replace:from_sunny sky;to_dark sky;preserve-geometry_true',
-      'e_gen_recolor:prompt_something;multiple_true;to-color_red',
+      'e_gen_replace:from_sunny sky;to_dark sky;multiple_true',
+      'e_gen_replace:from_sunny sky;to_dark sky;preserve-geometry_true;multiple_true',
+      'e_gen_recolor:prompt_something;to-color_red;multiple_true',
       'e_gen_recolor:prompt_(something;else);to-color_blue',
       'e_gen_restore'
     ].join('/'));

--- a/__TESTS__/unit/fromJson/generativeRemove.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/generativeRemove.fromJson.test.ts
@@ -5,16 +5,22 @@ describe("generativeRemove.fromJson", () => {
     const transformation = fromJson({
       actions: [
         { actionType: "generativeRemove", prompts: ["dog"] },
+        { actionType: "generativeRemove", prompts: ["dog", "cat"] },
         {
           actionType: "generativeRemove",
           prompts: ["dog"],
           detectMultiple: true,
         },
-        { actionType: "generativeRemove", prompts: ["dog", "cat"] },
         {
           actionType: "generativeRemove",
-          prompts: ["dog", "cat"],
+          prompts: ["dog"],
+          removeShadow: true,
+        },
+        {
+          actionType: "generativeRemove",
+          prompts: ["dog"],
           detectMultiple: true,
+          removeShadow: true,
         },
         {
           actionType: "generativeRemove",
@@ -32,9 +38,10 @@ describe("generativeRemove.fromJson", () => {
 
     expect(transformation.toString().split("/")).toStrictEqual([
       "e_gen_remove:prompt_dog",
+      "e_gen_remove:prompt_(dog;cat)",
       "e_gen_remove:prompt_dog;multiple_true",
-      "e_gen_remove:prompt_(dog;cat)",
-      "e_gen_remove:prompt_(dog;cat)",
+      "e_gen_remove:prompt_dog;remove-shadow_true",
+      "e_gen_remove:prompt_dog;multiple_true;remove-shadow_true",
       "e_gen_remove:region_(x_10;y_10;w_100;h_100)",
       "e_gen_remove:region_((x_10;y_10;w_100;h_100);(x_500;y_500;w_200;h_200))",
     ]);

--- a/__TESTS__/unit/toJson/effect.toJson.test.ts
+++ b/__TESTS__/unit/toJson/effect.toJson.test.ts
@@ -390,12 +390,19 @@ describe('Effect toJson()', () => {
 
   it('effect.GenerativeReplace', () => {
     const transformation = new Transformation()
-      .addAction(Effect.generativeReplace().from('ceiling').to('sunny sky').preserveGeometry())
       .addAction(Effect.generativeReplace().from('sunny sky').to('dark sky'))
-      .addAction(Effect.generativeReplace().from('sunny sky').to('dark sky').preserveGeometry(false));
+      .addAction(Effect.generativeReplace().from('ceiling').to('sunny sky').preserveGeometry())
+      .addAction(Effect.generativeReplace().from('sunny sky').to('dark sky').preserveGeometry(false))
+      .addAction(Effect.generativeReplace().from('ceiling').to('sunny sky').detectMultiple())
+      .addAction(Effect.generativeReplace().from('ceiling').to('sunny sky').detectMultiple(false));
 
     expect(transformation.toJson()).toStrictEqual({
       actions: [
+        {
+          actionType: 'generativeReplace',
+          from: 'sunny sky',
+          to: 'dark sky',
+        },
         {
           actionType: 'generativeReplace',
           from: 'ceiling',
@@ -409,8 +416,14 @@ describe('Effect toJson()', () => {
         },
         {
           actionType: 'generativeReplace',
-          from: 'sunny sky',
-          to: 'dark sky',
+          from: 'ceiling',
+          to: 'sunny sky',
+          detectMultiple: true
+        },
+        {
+          actionType: 'generativeReplace',
+          from: 'ceiling',
+          to: 'sunny sky',
         }
       ]
     });
@@ -418,13 +431,20 @@ describe('Effect toJson()', () => {
 
   it('effect.GenerativeRecolor', () => {
     const transformation = new Transformation()
+      .addAction(Effect.generativeRecolor('something', 'red'))
       .addAction(Effect.generativeRecolor('something', 'red').multiple())
       .addAction(Effect.generativeRecolor('something', 'red').multiple(false))
-      .addAction(Effect.generativeRecolor('something', 'red'))
+      .addAction(Effect.generativeRecolor('something', 'red').detectMultiple())
+      .addAction(Effect.generativeRecolor('something', 'red').detectMultiple(false))
       .addAction(Effect.generativeRecolor(['something', 'else'], 'red'));
 
     expect(transformation.toJson()).toStrictEqual({
       actions: [
+        {
+          actionType: 'generativeRecolor',
+          prompts: ['something'],
+          toColor: 'red',
+        },
         {
           actionType: 'generativeRecolor',
           prompts: ['something'],
@@ -435,6 +455,12 @@ describe('Effect toJson()', () => {
           actionType: 'generativeRecolor',
           prompts: ['something'],
           toColor: 'red',
+        },
+        {
+          actionType: 'generativeRecolor',
+          prompts: ['something'],
+          toColor: 'red',
+          detectMultiple: true,
         },
         {
           actionType: 'generativeRecolor',

--- a/__TESTS__/unit/toJson/generativeRemove.toJson.test.ts
+++ b/__TESTS__/unit/toJson/generativeRemove.toJson.test.ts
@@ -6,10 +6,7 @@ import { Region } from "../../../src/qualifiers/region";
 describe("GenerativeRemove.toJson()", () => {
   it("produces correct action JSON", () => {
     const testCases: Array<[GenerativeRemove, unknown]> = [
-      [
-        Effect.generativeRemove().prompt("dog"),
-        { actionType: "generativeRemove", prompts: ["dog"] },
-      ],
+      [Effect.generativeRemove().prompt("dog"), { actionType: "generativeRemove", prompts: ["dog"] }],
       [
         Effect.generativeRemove().prompt("dog").detectMultiple(),
         {
@@ -19,9 +16,23 @@ describe("GenerativeRemove.toJson()", () => {
         },
       ],
       [
-        Effect.generativeRemove().prompt("dog", "cat"),
-        { actionType: "generativeRemove", prompts: ["dog", "cat"] },
+        Effect.generativeRemove().prompt("dog").removeShadow(),
+        {
+          actionType: "generativeRemove",
+          prompts: ["dog"],
+          removeShadow: true,
+        },
       ],
+      [
+        Effect.generativeRemove().prompt("dog").detectMultiple().removeShadow(),
+        {
+          actionType: "generativeRemove",
+          prompts: ["dog"],
+          detectMultiple: true,
+          removeShadow: true,
+        },
+      ],
+      [Effect.generativeRemove().prompt("dog", "cat"), { actionType: "generativeRemove", prompts: ["dog", "cat"] }],
       [
         Effect.generativeRemove().region(Region.rectangle(50, 60, 600, 400)),
         {
@@ -30,10 +41,7 @@ describe("GenerativeRemove.toJson()", () => {
         },
       ],
       [
-        Effect.generativeRemove().region(
-          Region.rectangle(10, 20, 600, 400),
-          Region.rectangle(300, 400, 50, 60)
-        ),
+        Effect.generativeRemove().region(Region.rectangle(10, 20, 600, 400), Region.rectangle(300, 400, 50, 60)),
         {
           actionType: "generativeRemove",
           regions: [

--- a/src/actions/effect/GenerativeRecolor.ts
+++ b/src/actions/effect/GenerativeRecolor.ts
@@ -2,7 +2,7 @@ import { Action } from "../../internal/Action.js";
 import { QualifierValue } from "../../internal/qualifier/QualifierValue.js";
 import { Qualifier } from "../../internal/qualifier/Qualifier.js";
 import { IGenerativeRecolorModel } from "../../internal/models/IEffectActionModel.js";
-import {SystemColors} from "../../qualifiers/color.js";
+import { SystemColors } from "../../qualifiers/color.js";
 
 /**
  * @description A class that defines how to recolor objects in an asset using Generative AI
@@ -26,7 +26,7 @@ class GenerativeRecolor extends Action {
     this._actionModel.toColor = this._toColor;
   }
 
-  multiple(value = true) {
+  detectMultiple(value = true) {
     this._detectMultiple = value;
 
     if (this._detectMultiple) {
@@ -36,15 +36,25 @@ class GenerativeRecolor extends Action {
     return this;
   }
 
+  // Alias method to be backwards compatible
+  multiple = this.detectMultiple.bind(this);
+
   protected prepareQualifiers(): void {
     const qualifierValue = new QualifierValue().setDelimiter(";");
 
     if (this._prompts.length) {
       qualifierValue.addValue(this.preparePromptValue());
     }
+
     if (this._toColor) {
-      const formattedColor = this._toColor.match(/^#/) ? this._toColor.substr(1) : this._toColor;
+      const formattedColor = this._toColor.match(/^#/)
+        ? this._toColor.substr(1)
+        : this._toColor;
       qualifierValue.addValue(`to-color_${formattedColor}`);
+    }
+
+    if (this._detectMultiple) {
+      qualifierValue.addValue("multiple_true");
     }
 
     this.addQualifier(
@@ -54,16 +64,10 @@ class GenerativeRecolor extends Action {
 
   private preparePromptValue() {
     const prompts = this._prompts;
-    const detectMultiple = this._detectMultiple;
-
     const qualifierValue = new QualifierValue().setDelimiter(";");
 
     if (prompts.length === 1) {
       qualifierValue.addValue(`prompt_${prompts[0]}`);
-
-      if (detectMultiple) {
-        qualifierValue.addValue("multiple_true");
-      }
     } else {
       qualifierValue.addValue(`prompt_(${prompts.join(";")})`);
     }
@@ -76,7 +80,7 @@ class GenerativeRecolor extends Action {
     const result = new this(prompts, toColor);
 
     if (detectMultiple) {
-      result.multiple(detectMultiple);
+      result.detectMultiple(detectMultiple);
     }
 
     return result;

--- a/src/actions/effect/GenerativeReplace.ts
+++ b/src/actions/effect/GenerativeReplace.ts
@@ -12,6 +12,7 @@ class GenerativeReplace extends Action {
   private _from: string;
   private _to: string;
   private _preserveGeometry = false;
+  private _detectMultiple = false;
 
   constructor() {
     super();
@@ -42,6 +43,16 @@ class GenerativeReplace extends Action {
     return this;
   }
 
+  detectMultiple(value = true) {
+    this._detectMultiple = value;
+
+    if (this._detectMultiple) {
+      this._actionModel.detectMultiple = this._detectMultiple;
+    }
+
+    return this;
+  }
+
   protected prepareQualifiers(): void {
     let str = `gen_replace:from_${this._from};to_${this._to}`;
 
@@ -49,11 +60,15 @@ class GenerativeReplace extends Action {
       str += `;preserve-geometry_true`;
     }
 
+    if (this._detectMultiple) {
+      str += `;multiple_true`;
+    }
+
     this.addQualifier(new Qualifier("e", str));
   }
 
   static fromJson(actionModel: IGenerativeReplaceModel): GenerativeReplace {
-    const { from, to, preserveGeometry } = actionModel;
+    const { from, to, preserveGeometry, detectMultiple } = actionModel;
     const result = new this();
 
     result.from(from);
@@ -61,6 +76,10 @@ class GenerativeReplace extends Action {
 
     if (preserveGeometry) {
       result.preserveGeometry();
+    }
+
+    if (detectMultiple) {
+      result.detectMultiple();
     }
 
     return result;

--- a/src/internal/models/IEffectActionModel.ts
+++ b/src/internal/models/IEffectActionModel.ts
@@ -1,6 +1,6 @@
 import { IActionModel } from "./IActionModel.js";
 import { ForegroundObjectValue } from "../../qualifiers/foregroundObject.js";
-import {SystemColors} from "../../qualifiers/color.js";
+import { SystemColors } from "../../qualifiers/color.js";
 
 interface IEffectActionWithLevelModel extends IActionModel {
   level?: number;
@@ -105,6 +105,7 @@ interface IGenerativeRemoveModel extends IActionModel {
   prompts?: Array<string>;
   regions?: Array<{ x: number; y: number; width: number; height: number }>;
   detectMultiple?: boolean;
+  removeShadow?: boolean;
 }
 
 interface IGenerativeRecolorModel extends IActionModel {
@@ -117,6 +118,7 @@ interface IGenerativeReplaceModel extends IActionModel {
   from?: string;
   to?: string;
   preserveGeometry?: boolean;
+  detectMultiple?: boolean;
 }
 
 export {


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk

* Add `decectMultiple` method to `GenerativeReplace` 
* Add `removeShadow` method to `GenerativeRemove`
* Create `decectMultiple` alias for `GenerativeRecolor#multiple` method  to be compatible with other "generative" actions 

#### What does this PR solve?
Implements  new parameters for a several generative actions


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
