### PR TITLE
Add support for "auto" offsets in VideoEdit.trim

### DIFF
--- a/__TESTS__/unit/actions/VideoEdit.test.ts
+++ b/__TESTS__/unit/actions/VideoEdit.test.ts
@@ -81,6 +81,17 @@ describe('Tests for Transformation Action -- VideoEdit', () => {
     expect(tx).toBe('du_10p,eo_4p,so_3p');
   });
 
+  it('Tests an auto offset', () => {
+    const tx = new Transformation()
+      .videoEdit(
+        VideoEdit.trim()
+          .startOffset("auto")
+          .endOffset("auto")
+      ).toString();
+
+    expect(tx).toContain('eo_auto,so_auto');
+  });
+
   it('Creates a Transformation with volume string', () => {
     const tx = new Transformation()
       .videoEdit(VideoEdit.volume('5db'))

--- a/__TESTS__/unit/fromJson/videoEditTrim.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/videoEditTrim.fromJson.test.ts
@@ -2,7 +2,7 @@ import {fromJson} from "../../../src/internal/fromJson";
 import {ITrimActionModel} from "../../../src/internal/models/ITrimActionModel";
 
 describe('videoEdit.trim fromJson', () => {
-  it('Should generate TrimAction from model', () => {
+  it('should generate TrimAction from model', () => {
     const trimModel: ITrimActionModel = {
       actionType: 'trimVideo',
       duration: '30%',
@@ -13,7 +13,7 @@ describe('videoEdit.trim fromJson', () => {
     expect(transformation.toString()).toStrictEqual('du_30p');
   });
 
-  it('Should generate ConcatenateAction with transition from model', () => {
+  it('should generate ConcatenateAction with transition from model', () => {
     const trimModel: ITrimActionModel = {
       actionType: 'trimVideo',
       startOffset: 3,
@@ -24,7 +24,7 @@ describe('videoEdit.trim fromJson', () => {
     expect(transformation.toString()).toStrictEqual('eo_5,so_3');
   });
 
-  it('Should generate ConcatenateAction with ImageSource and transition from model', () => {
+  it('should generate ConcatenateAction with ImageSource and transition from model', () => {
     const trimModel: ITrimActionModel = {
       actionType: 'trimVideo',
       startOffset: 3,
@@ -34,5 +34,18 @@ describe('videoEdit.trim fromJson', () => {
     const transformation = fromJson({actions: [trimModel]});
 
     expect(transformation.toString()).toStrictEqual('du_5,so_3');
+  });
+
+  it('should generate auto offsets', () => {
+    const trimModel: ITrimActionModel = {
+      actionType: 'trimVideo',
+      startOffset: "auto",
+      endOffset: "auto",
+      duration: 5,
+    };
+
+    const transformation = fromJson({actions: [trimModel]});
+
+    expect(transformation.toString()).toStrictEqual('du_5,eo_auto,so_auto');
   });
 });

--- a/__TESTS__/unit/toJson/videoEditTrim.toJson.test.ts
+++ b/__TESTS__/unit/toJson/videoEditTrim.toJson.test.ts
@@ -50,4 +50,21 @@ describe('videoEdit.trim toJson', () => {
       ]
     });
   });
+
+  it('videoEdit.trim with auto offsets', () => {
+    const transformation = new Transformation()
+      .videoEdit(VideoEdit.trim()
+        .startOffset("auto")
+        .endOffset("auto")
+      );
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'trimVideo',
+          startOffset: "auto",
+          endOffset: "auto",
+        }
+      ]
+    });
+  });
 });

--- a/src/actions/videoEdit/TrimAction.ts
+++ b/src/actions/videoEdit/TrimAction.ts
@@ -39,7 +39,7 @@ class TrimAction extends Action {
    * @return {this}
    */
   startOffset(offset: string|number): this {
-    this._actionModel.startOffset = +offset;
+    this._actionModel.startOffset = getAuto(offset) || +offset;
     return this.addQualifier(new Qualifier('so', this.parseVal(offset)));
   }
 
@@ -52,7 +52,7 @@ class TrimAction extends Action {
    * @return {this}
    */
   endOffset(offset: string|number): this {
-    this._actionModel.endOffset = +offset;
+    this._actionModel.endOffset = getAuto(offset) || +offset;
     return this.addQualifier(new Qualifier('eo', this.parseVal(offset)));
   }
 
@@ -89,5 +89,11 @@ class TrimAction extends Action {
     return result;
   }
 }
+
+
+/**
+ * Helper function that either gets 'auto' or return null
+ */
+const getAuto = (value: unknown): 'auto' | null => value === 'auto' ? value : null;
 
 export default TrimAction;

--- a/src/internal/models/ITrimActionModel.ts
+++ b/src/internal/models/ITrimActionModel.ts
@@ -2,6 +2,6 @@ import {IActionModel} from "./IActionModel.js";
 
 export interface ITrimActionModel extends IActionModel{
   duration?: string | number;
-  startOffset?: number;
-  endOffset?: number;
+  startOffset?: "auto" | number;
+  endOffset?:"auto" | number;
 }


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
Fixes bug for "auto" `VideoEdit.trim`.

```typescript
 VideoEdit.trim().startOffset("auto") // returns "so_auto" instead of "so_NaN"
 VideoEdit.trim().endOffest("auto") // returns "eo_auto" instead of "eo_NaN"
```

#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
