### PR TITLE
Add color mapping and missing internals in backgroundColor

### DIFF
--- a/__TESTS__/unit/fromJson/backgroundColor.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/backgroundColor.fromJson.test.ts
@@ -1,0 +1,16 @@
+import {fromJson} from "../../../src/internal/fromJson";
+
+describe('backgroundColor.fromJson', () => {
+  it('should generate a url with border from array of models', function () {
+    const transformation = fromJson({actions:
+        [
+          { actionType: 'backgroundColor', color: 'red' },
+          { actionType: 'backgroundColor', color: '#000000' },
+        ]}
+    );
+    expect(transformation.toString()).toStrictEqual(
+      'b_red/b_rgb:000000'
+    );
+  });
+});
+

--- a/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
+++ b/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
@@ -1,0 +1,14 @@
+import {Transformation} from "../../../src";
+import {BackgroundColor} from "../../../src/actions/background/actions/BackgroundColor.js";
+
+describe('BackgroundColor toJson()', () => {
+  it('backgroundColor', () => {
+    const transformation = new Transformation()
+      .addAction(new BackgroundColor('white'))
+      .addAction(new BackgroundColor('#ffffff'));
+    expect(transformation.toJson()).toStrictEqual({actions: [
+      { actionType: 'backgroundColor', color: 'white' },
+      { actionType: 'backgroundColor', color: '#ffffff' }
+    ]});
+  });
+});

--- a/__TESTS__/unit/toJson/overlayUnderlay.toJson.test.ts
+++ b/__TESTS__/unit/toJson/overlayUnderlay.toJson.test.ts
@@ -17,7 +17,7 @@ import {Timeline} from "../../../src/qualifiers/timeline";
 import {BlendMode} from "../../../src/qualifiers/blendMode";
 import {TextStyle} from "../../../src/qualifiers/textStyle";
 import {FontAntialias} from "../../../src/qualifiers/FontAntialias";
-import {Underlay} from "../../../src/actions";
+import {PSDTools, Underlay} from "../../../src/actions";
 import {UnsupportedError} from "../../../src/internal/utils/unsupportedError";
 
 describe('Overlay & Underlay toJson', () => {
@@ -269,13 +269,13 @@ describe('Overlay & Underlay toJson', () => {
     transformation.addAction(
       Overlay.source(Source.image('sample').transformation(new Transformation()
         .resize(scale(100).width(800))
-        .backgroundColor("red")
+        .psdTools(PSDTools.clip().byIndex(9))
       ))
     );
 
     expect(transformation.toJson()).toStrictEqual(
       {
-        error: new UnsupportedError('unsupported action BackgroundColor')
+        error: new UnsupportedError('unsupported action ClipAction')
       }
     );
   });

--- a/src/actions/background/actions/BackgroundColor.ts
+++ b/src/actions/background/actions/BackgroundColor.ts
@@ -2,15 +2,33 @@ import {Action} from "../../../internal/Action.js";
 import {QualifierValue} from "../../../internal/qualifier/QualifierValue.js";
 import {Qualifier} from "../../../internal/qualifier/Qualifier.js";
 import {SystemColors} from "../../../qualifiers/color.js";
+import {IActionModel} from "../../../internal/models/IActionModel.js";
+import {IBackgroundColorActionModel} from "../../../internal/models/IBackgroundColorActionModel.js";
+import {prepareColor} from "../../../internal/utils/prepareColor.js";
+import {IBackgroundColorModel} from "../../../internal/models/IEffectActionModel.js";
 
 /**
  * @extends SDK.Action
  * @description A class for background transformations.
  */
 class BackgroundColor extends Action {
+  protected _actionModel: IBackgroundColorModel = {};
+
   constructor(color: SystemColors) {
     super();
-    this.addQualifier(new Qualifier('b', new QualifierValue(color).setDelimiter('_')));
+    this.addQualifier(new Qualifier('b', new QualifierValue(prepareColor(color)).setDelimiter('_')));
+    this._actionModel.color = color;
+    this._actionModel.actionType = 'backgroundColor';
+  }
+
+  static fromJson(actionModel: IActionModel): BackgroundColor {
+    const { color } = (actionModel as IBackgroundColorActionModel);
+
+    // We are using this() to allow inheriting classes to use super.fromJson.apply(this, [actionModel])
+    // This allows the inheriting classes to determine the class to be created
+    const result = new this(color);
+
+    return result;
   }
 }
 

--- a/src/internal/fromJson.ts
+++ b/src/internal/fromJson.ts
@@ -70,6 +70,7 @@ import { GenerativeRemove } from "../actions/effect/GenerativeRemove.js";
 import { GenerativeReplace } from "../actions/effect/GenerativeReplace.js";
 import { GenerativeRecolor } from "../actions/effect/GenerativeRecolor.js";
 import {ResizeAdvancedAction} from "../actions/resize/ResizeAdvancedAction.js";
+import {BackgroundColor} from "../actions/background/actions/BackgroundColor.js";
 
 const ActionModelMap: Record<string, IHasFromJson> = {
   scale: ResizeScaleAction,
@@ -150,6 +151,7 @@ const ActionModelMap: Record<string, IHasFromJson> = {
   generativeRestore: SimpleEffectAction,
   upscale: SimpleEffectAction,
   auto: ResizeAdvancedAction,
+  backgroundColor: BackgroundColor,
 };
 
 /**

--- a/src/internal/models/IBackgroundColorActionModel.ts
+++ b/src/internal/models/IBackgroundColorActionModel.ts
@@ -1,0 +1,8 @@
+import {IActionModel} from "./IActionModel.js";
+import {IColorModel} from "./IColorModel.js";
+
+interface IBackgroundColorActionModel extends IActionModel {
+  color: IColorModel;
+}
+
+export {IBackgroundColorActionModel};

--- a/src/internal/models/IEffectActionModel.ts
+++ b/src/internal/models/IEffectActionModel.ts
@@ -135,6 +135,10 @@ interface IGenerativeReplaceModel extends IActionModel {
   detectMultiple?: boolean;
 }
 
+interface IBackgroundColorModel extends IActionModel {
+  color?: SystemColors | string;
+}
+
 export {
   IEffectActionWithLevelModel,
   ISimpleEffectActionModel,
@@ -159,4 +163,5 @@ export {
   IGenerativeRemoveModel,
   IGenerativeReplaceModel,
   IGenerativeRecolorModel,
+  IBackgroundColorModel,
 };


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Add color mapping to properly map hex colors, e.g. `colorBackground('#00FFFF')` into `rgb:00FFFF`
- Add missing internal utilities (`fromJson`, `toJson`)


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
