### PR TITLE
Make bgColor mapping bulletproof regardless of syntax version

### DIFF
--- a/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
+++ b/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
@@ -19,5 +19,5 @@ describe('BackgroundColor toJson()', () => {
       { actionType: 'backgroundColor', color: 'white' },
       { actionType: 'backgroundColor', color: '#ffffff' }
     ]});
-  })
+  });
 });

--- a/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
+++ b/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
@@ -16,8 +16,8 @@ describe('BackgroundColor toJson()', () => {
       .backgroundColor('white')
       .backgroundColor('#ffffff');
     expect(transformation.toJson()).toStrictEqual({actions: [
-        { actionType: 'backgroundColor', color: 'white' },
-        { actionType: 'backgroundColor', color: '#ffffff' }
-      ]});
+      { actionType: 'backgroundColor', color: 'white' },
+      { actionType: 'backgroundColor', color: '#ffffff' }
+    ]});
   })
 });

--- a/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
+++ b/__TESTS__/unit/toJson/backgroundColor.toJson.test.ts
@@ -2,7 +2,7 @@ import {Transformation} from "../../../src";
 import {BackgroundColor} from "../../../src/actions/background/actions/BackgroundColor.js";
 
 describe('BackgroundColor toJson()', () => {
-  it('backgroundColor', () => {
+  it('new BackgroundColor', () => {
     const transformation = new Transformation()
       .addAction(new BackgroundColor('white'))
       .addAction(new BackgroundColor('#ffffff'));
@@ -11,4 +11,13 @@ describe('BackgroundColor toJson()', () => {
       { actionType: 'backgroundColor', color: '#ffffff' }
     ]});
   });
+  it('.backgroundColor()', () => {
+    const transformation = new Transformation()
+      .backgroundColor('white')
+      .backgroundColor('#ffffff');
+    expect(transformation.toJson()).toStrictEqual({actions: [
+        { actionType: 'backgroundColor', color: 'white' },
+        { actionType: 'backgroundColor', color: '#ffffff' }
+      ]});
+  })
 });

--- a/src/transformation/Transformation.ts
+++ b/src/transformation/Transformation.ts
@@ -246,7 +246,7 @@ class Transformation {
    * @return {this}
    */
   backgroundColor(color: SystemColors): this {
-    return this.addAction(new BackgroundColor(prepareColor(color)));
+    return this.addAction(new BackgroundColor(color));
   }
 
   /**


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Ensure the same color mapping in `toJson` regardless of syntax version


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
