### PR TITLE
Fix blurred background default params handling

### DIFF
--- a/__TESTS__/unit/actions/Background.test.ts
+++ b/__TESTS__/unit/actions/Background.test.ts
@@ -139,17 +139,38 @@ describe('Tests for Transformation Action -- Background', () => {
       )
       .toString();
 
-    expect(tx).toContain('b_blurred');
+    expect(tx).toContain('b_blurred,');
   });
 
-  it('Test blurred background with one qualifiers', () => {
+  it('Test blurred background with intensity qualifier only', () => {
     const tx = new Transformation()
       .resize(Resize.pad(250, 250)
-        .background(blurred().intensity(100).brightness(100))
+        .background(blurred().intensity(500))
       )
       .toString();
 
-    expect(tx).toContain('b_blurred:100:100');
+    expect(tx).toContain('b_blurred:500,');
+  });
+
+  it('Test blurred background with brightness qualifier only', () => {
+    const tx = new Transformation()
+      .resize(Resize.pad(250, 250)
+        .background(blurred().brightness(500))
+      )
+      .toString();
+
+    // default intensity = 100
+    expect(tx).toContain('b_blurred:100:500,');
+  });
+
+  it('Test blurred background with two qualifiers', () => {
+    const tx = new Transformation()
+      .resize(Resize.pad(250, 250)
+        .background(blurred().intensity(200).brightness(100))
+      )
+      .toString();
+
+    expect(tx).toContain('b_blurred:200:100,');
   });
 
   describe('Test generative fill background', () => {

--- a/__TESTS__/unit/fromJson/resize.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/resize.fromJson.test.ts
@@ -92,6 +92,22 @@ describe('resize.fromJson', () => {
     expect(transformation.toString()).toStrictEqual(fromJson(json).toString());
   });
 
+  it('Should generate BlurredBackground from model', ()=>{
+    const transformation1 = fromJson({actions: [
+      {actionType: 'pad', dimensions: {width: 100}, background: {backgroundType: 'blurred'}},
+    ]});
+    const transformation2 = fromJson({actions: [
+      {actionType: 'pad', dimensions: {width: 100}, background: {backgroundType: 'blurred', intensity: 2000}},
+    ]});
+    const transformation3 = fromJson({actions: [
+      {actionType: 'pad', dimensions: {width: 100}, background: {backgroundType: 'blurred', brightness: 500}},
+    ]});
+
+    expect(transformation1.toString()).toStrictEqual('b_blurred:100:0,c_pad,w_100');
+    expect(transformation2.toString()).toStrictEqual('b_blurred:2000:0,c_pad,w_100');
+    expect(transformation3.toString()).toStrictEqual('b_blurred:100:500,c_pad,w_100');
+  });
+
   it('Should generate AutoBackground from model', ()=>{
     const transformation = fromJson({actions: [
       {actionType: 'pad', dimensions: {width: 100}, background: {backgroundType: 'auto'}},

--- a/src/internal/models/createBackgroundFromModel.ts
+++ b/src/internal/models/createBackgroundFromModel.ts
@@ -22,7 +22,7 @@ import {
 } from "../../qualifiers/background.js";
 import {BackgroundAutoPredominantQualifier} from "../../qualifiers/background/shared/auto/BackgroundAutoPredominantQualifier.js";
 import {BackgroundGenerativeFillQualifier} from "../../qualifiers/background/shared/BackgroundGenerativeFillQualifier.js";
-import {DEFAULT_BRIGHTNESS, DEFAULT_INTENSITY} from "../../qualifiers/background/shared/BlurredBackgroundAction";
+import {DEFAULT_BRIGHTNESS, DEFAULT_INTENSITY} from "../../qualifiers/background/shared/BlurredBackgroundAction.js";
 
 /**
  * Create BackgroundQualifier from IBlurredBackgroundModel

--- a/src/internal/models/createBackgroundFromModel.ts
+++ b/src/internal/models/createBackgroundFromModel.ts
@@ -22,6 +22,7 @@ import {
 } from "../../qualifiers/background.js";
 import {BackgroundAutoPredominantQualifier} from "../../qualifiers/background/shared/auto/BackgroundAutoPredominantQualifier.js";
 import {BackgroundGenerativeFillQualifier} from "../../qualifiers/background/shared/BackgroundGenerativeFillQualifier.js";
+import {DEFAULT_BRIGHTNESS, DEFAULT_INTENSITY} from "../../qualifiers/background/shared/BlurredBackgroundAction";
 
 /**
  * Create BackgroundQualifier from IBlurredBackgroundModel
@@ -31,13 +32,8 @@ function createBlurredBackground(backgroundModel: IBlurredBackgroundModel): Back
   const {brightness, intensity} = backgroundModel;
   const result = Background.blurred();
 
-  if (brightness || brightness == 0) {
-    result.brightness(brightness);
-  }
-
-  if (intensity || intensity == 0) {
-    result.intensity(intensity);
-  }
+  result.brightness(brightness ?? DEFAULT_BRIGHTNESS);
+  result.intensity(intensity ?? DEFAULT_INTENSITY);
 
   return result;
 }

--- a/src/qualifiers/background/shared/BlurredBackgroundAction.ts
+++ b/src/qualifiers/background/shared/BlurredBackgroundAction.ts
@@ -1,5 +1,8 @@
 import {BackgroundQualifier} from "./base/BackgroundQualifier.js";
 
+export const DEFAULT_INTENSITY = 100;
+export const DEFAULT_BRIGHTNESS = 0;
+
 /**
  * @description A class for blurred background transformations.
  * @memberOf Qualifiers.Background
@@ -36,8 +39,12 @@ class BlurredBackgroundAction extends BackgroundQualifier {
     // b_blurred:{intensity}:{brightness}
     return `
     b_blurred
-    ${this.intensityLevel ? `:${this.intensityLevel}` : ''}
-    ${this.brightnessLevel ? `:${this.brightnessLevel}` : ''}
+    ${this.intensityLevel !== undefined ? `:${this.intensityLevel}` : ''}
+    ${this.brightnessLevel !== undefined 
+      ? this.intensityLevel !== undefined 
+        ? `:${this.brightnessLevel}` 
+        : `:${DEFAULT_INTENSITY}:${this.brightnessLevel}` 
+      : ''}
     `.replace(/\s+/g, '');
   }
 }

--- a/src/qualifiers/background/shared/BlurredBackgroundAction.ts
+++ b/src/qualifiers/background/shared/BlurredBackgroundAction.ts
@@ -37,15 +37,15 @@ class BlurredBackgroundAction extends BackgroundQualifier {
    */
   toString(): string {
     // b_blurred:{intensity}:{brightness}
-    return `
-    b_blurred
-    ${this.intensityLevel !== undefined ? `:${this.intensityLevel}` : ''}
-    ${this.brightnessLevel !== undefined 
-      ? this.intensityLevel !== undefined 
-        ? `:${this.brightnessLevel}` 
-        : `:${DEFAULT_INTENSITY}:${this.brightnessLevel}` 
-      : ''}
-    `.replace(/\s+/g, '');
+
+    const intensity = this.intensityLevel !== undefined ? `:${this.intensityLevel}` : '';
+    const brightness = this.brightnessLevel !== undefined
+      ? this.intensityLevel !== undefined
+        ? `:${this.brightnessLevel}`
+        : `:${DEFAULT_INTENSITY}:${this.brightnessLevel}`
+      : '';
+
+    return `b_blurred${intensity}${brightness}`;
   }
 }
 


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- For the SDK usage - fix case with applying only `brightness` property to the blurred background 
(it was assigned to `intensity` param in the URL syntax)
- For the `fromJson` internal utility - always include both params in the returned URL 
_(for static default values in the Builder)_


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
