### PR TITLE
Fix path to ExtractModeType

### DIFF
--- a/src/internal/models/IEffectActionModel.ts
+++ b/src/internal/models/IEffectActionModel.ts
@@ -1,7 +1,7 @@
 import { IActionModel } from "./IActionModel.js";
 import { ForegroundObjectValue } from "../../qualifiers/foregroundObject.js";
 import { SystemColors } from "../../qualifiers/color.js";
-import { ExtractModeType } from "types/types.js";
+import { ExtractModeType } from "../../types/types.js";
 
 interface IEffectActionWithLevelModel extends IActionModel {
   level?: number;


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
Fix for the [issue](https://github.com/cloudinary/js-transformation-builder-sdk/issues/58) where a relative path to the types was missing.


#### Final checklist
- [ ] Implementation is aligned to Spec.
- [ ] Tests - Add proper tests to the added code.
