### PR TITLE
Allow usage of strings in autoFocus.focusOn

### DIFF
--- a/__TESTS__/unit/values/gravity/Gravity.test.ts
+++ b/__TESTS__/unit/values/gravity/Gravity.test.ts
@@ -1,4 +1,5 @@
-import {Gravity} from "../../../../src/qualifiers/gravity";
+import {Gravity, autoGravity} from "../../../../src/qualifiers/gravity";
+import {focusOn} from "../../../../src/qualifiers/autoFocus";
 import {crop} from "../../../../src/actions/resize";
 import {Transformation} from "../../../../src";
 
@@ -15,5 +16,13 @@ describe('Gravity Qualifier', () => {
         .height(250)
         .gravity('auto')).toString();
     expect(tx).toContain('c_crop,g_auto,h_250,w_250');
+  });
+  it('Can use any string in autoFocus.focusOn()', ()=>{
+    const tx = new Transformation()
+      .resize(crop()
+        .width(250)
+        .height(250)
+        .gravity(autoGravity().autoFocus(focusOn("ball")))).toString();
+    expect(tx).toContain('c_crop,g_auto:ball,h_250,w_250');
   });
 });

--- a/src/qualifiers/autoFocus.ts
+++ b/src/qualifiers/autoFocus.ts
@@ -26,8 +26,9 @@ class AutoFocus extends QualifierValue {
    * @param {Qualifiers.FocusOn} obj The object to focus on.
    * @param {number} weight
    */
-  static focusOn(obj: FocusOnValue, weight?: number): AutoFocus {
-    return new AutoFocus(obj, weight);
+  static focusOn(obj: FocusOnValue | string, weight?: number): AutoFocus {
+    const focusOn = obj instanceof FocusOnValue ? obj : new FocusOnValue(obj);
+    return new AutoFocus(focusOn, weight);
   }
 
   constructor(focusOn: FocusOnValue, weight?: number | string) {


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
- Allow usage of strings in `autoFocus.focusOn` qualifier _(issue ref.: `SNI-8237`)_


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
