### PR TITLE
Add support for preserve-alpha attribute in e_extract

### DIFF
--- a/__TESTS__/unit/fromJson/effect.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/effect.fromJson.test.ts
@@ -53,10 +53,6 @@ describe('effect.fromJson', () => {
       { actionType: 'generativeBackgroundReplace', prompt: 'dog, dog (dog)' },
       { actionType: 'generativeBackgroundReplace', prompt: '!@#$%^&*()_+{}|":?><' },
       { actionType: 'generativeBackgroundReplace'},
-      { actionType: 'extract', 'prompts': 'blue sky' },
-      { actionType: 'extract', 'prompts': ['blue sky', 'yellow sun'], detectMultiple: true },
-      { actionType: 'extract', 'prompts': ['green grass'], mode: 'mask', invert: true },
-      { actionType: 'extract', 'prompts': ['yellow sun', 'green grass'], mode: 'content' },
       { actionType: 'pad', 'dimensions': { width: 100, height: 200 }, 'background': { backgroundType: 'generativeFill', prompt: 'some; test (123!)'} },
       { actionType: 'pad', 'dimensions': { width: 140, height: 240 }, 'background': { backgroundType: 'generativeFill', prompt: 'some%test ? (123/)'} },
     ]});
@@ -112,10 +108,6 @@ describe('effect.fromJson', () => {
       'e_gen_background_replace:prompt_dog%2C dog %28dog%29',
       'e_gen_background_replace:prompt_%21%40%23%24%25%5E%26%2A%28%29%5F%2B%7B%7D%7C%22%3A%3F%3E%3C',
       'e_gen_background_replace',
-      'e_extract:prompt_blue sky',
-      'e_extract:prompt_(blue sky;yellow sun);multiple_true',
-      'e_extract:prompt_green grass;mode_mask;invert_true',
-      'e_extract:prompt_(yellow sun;green grass);mode_content',
       'b_gen_fill:prompt_some%3B test %28123%21%29,c_pad,h_200,w_100',
       'b_gen_fill:prompt_some%25test %3F %28123%2F%29,c_pad,h_240,w_140',
     ]);

--- a/__TESTS__/unit/fromJson/extract.fromJson.test.ts
+++ b/__TESTS__/unit/fromJson/extract.fromJson.test.ts
@@ -1,0 +1,21 @@
+import {fromJson} from "../../../src/internal/fromJson";
+
+describe('extract.fromJson', () => {
+  it('should generate the correct transforamtion string with e_extract', function () {
+    const transformation = fromJson({actions:[
+      { actionType: 'extract', 'prompts': 'blue sky' },
+      { actionType: 'extract', 'prompts': ['blue sky', 'yellow sun'], detectMultiple: true },
+      { actionType: 'extract', 'prompts': ['green grass'], mode: 'mask', invert: true },
+      { actionType: 'extract', 'prompts': ['yellow sun', 'green grass'], mode: 'content' },
+      { actionType: 'extract', 'prompts': ['blue sky'], preserveAlpha: true },
+    ]});
+
+    expect(transformation.toString().split('/')).toStrictEqual([
+      'e_extract:prompt_blue sky',
+      'e_extract:prompt_(blue sky;yellow sun);multiple_true',
+      'e_extract:prompt_green grass;mode_mask;invert_true',
+      'e_extract:prompt_(yellow sun;green grass);mode_content',
+      'e_extract:prompt_blue sky;preserve-alpha_true',
+    ]);
+  });
+}); 

--- a/__TESTS__/unit/toJson/effect.toJson.test.ts
+++ b/__TESTS__/unit/toJson/effect.toJson.test.ts
@@ -514,46 +514,6 @@ describe('Effect toJson()', () => {
     });
   });
 
-  it('effect.extract', () => {
-    const transformation = new Transformation()
-      .addAction(Effect.extract('palms'))
-      .addAction(Effect.extract(['man']).mode('mask'))
-      .addAction(Effect.extract('woman').invert(true))
-      .addAction(Effect.extract(['cats', 'dogs']).detectMultiple(true))
-      .addAction(Effect.extract(['dogs', 'cats']).mode('content').detectMultiple(true).invert(false));
-
-
-    expect(transformation.toJson()).toStrictEqual({
-      actions: [
-        {
-          actionType: 'extract',
-          prompts: ['palms'],
-        },
-        {
-          actionType: 'extract',
-          prompts: ['man'],
-          mode: 'mask',
-        },
-        {
-          actionType: 'extract',
-          prompts: ['woman'],
-          invert: true,
-        },
-        {
-          actionType: 'extract',
-          prompts: ['cats', 'dogs'],
-          detectMultiple: true,
-        },
-        {
-          actionType: 'extract',
-          prompts: ['dogs', 'cats'],
-          mode: 'content',
-          detectMultiple: true
-        },
-      ]
-    });
-  });
-
   it('effect.GenerativeRecolor', () => {
     const transformation = new Transformation()
       .addAction(Effect.generativeRecolor('something', 'red'))

--- a/__TESTS__/unit/toJson/extract.toJson.test.ts
+++ b/__TESTS__/unit/toJson/extract.toJson.test.ts
@@ -1,0 +1,62 @@
+import { Transformation } from "../../../src";
+import { Effect } from "../../../src/actions/effect";
+
+describe("Extract.toJson()", () => {
+  it("produces correct action JSON for extract (including preserveAlpha, invert, detectMultiple, and mode)", () => {
+    const transformation = new Transformation()
+      .addAction(Effect.extract('palms'))
+      .addAction(Effect.extract(['man']).mode('mask'))
+      .addAction(Effect.extract('woman').invert())
+      .addAction(Effect.extract('woman').invert(true))
+      .addAction(Effect.extract(['cats', 'dogs']).detectMultiple(true))
+      .addAction(Effect.extract(['dogs', 'cats']).mode('content').detectMultiple(true).invert(false))
+      .addAction(Effect.extract('sky').preserveAlpha())
+      .addAction(Effect.extract('sky').invert(true).preserveAlpha(true));
+
+    expect(transformation.toJson()).toStrictEqual({
+      actions: [
+        {
+          actionType: 'extract',
+          prompts: ['palms'],
+        },
+        {
+          actionType: 'extract',
+          prompts: ['man'],
+          mode: 'mask',
+        },
+        {
+          actionType: 'extract',
+          prompts: ['woman'],
+          invert: true,
+        },
+        {
+          actionType: 'extract',
+          prompts: ['woman'],
+          invert: true,
+        },
+        {
+          actionType: 'extract',
+          prompts: ['cats', 'dogs'],
+          detectMultiple: true,
+        },
+        {
+          actionType: 'extract',
+          prompts: ['dogs', 'cats'],
+          mode: 'content',
+          detectMultiple: true
+        },
+        {
+          actionType: 'extract',
+          prompts: ['sky'],
+          preserveAlpha: true
+        },
+        {
+          actionType: 'extract',
+          prompts: ['sky'],
+          invert: true,
+          preserveAlpha: true
+        }
+      ]
+    });
+  });
+}); 

--- a/src/actions/effect/Extract.ts
+++ b/src/actions/effect/Extract.ts
@@ -15,6 +15,7 @@ class Extract extends Action {
   private _detectMultiple = false;
   private _mode: ExtractModeType;
   private _invert = false;
+  private _preserveAlpha = false;
 
   constructor(prompts: string | string[]) {
     super();
@@ -41,11 +42,21 @@ class Extract extends Action {
     return this;
   }
 
-  invert(value = false) {
+  invert(value = true) {
     this._invert = value;
 
     if (this._invert) {
       this._actionModel.invert = this._invert;
+    }
+
+    return this;
+  }
+
+  preserveAlpha(value = true) {
+    this._preserveAlpha = value;
+
+    if (this._preserveAlpha) {
+      this._actionModel.preserveAlpha = this._preserveAlpha;
     }
 
     return this;
@@ -70,6 +81,10 @@ class Extract extends Action {
       qualifierValue.addValue("invert_true");
     }
 
+    if (this._preserveAlpha) {
+      qualifierValue.addValue("preserve-alpha_true");
+    }
+
     this.addQualifier(
       new Qualifier("e", `extract:${qualifierValue.toString()}`)
     );
@@ -89,7 +104,7 @@ class Extract extends Action {
   }
 
   static fromJson(actionModel: IExtractModel): Extract {
-    const { prompts, detectMultiple, mode, invert } = actionModel;
+    const { prompts, detectMultiple, mode, invert, preserveAlpha } = actionModel;
     const result = new this(prompts);
 
     if (detectMultiple) {
@@ -102,6 +117,10 @@ class Extract extends Action {
 
     if (invert) {
       result.invert(invert);
+    }
+
+    if (preserveAlpha) {
+      result.preserveAlpha(preserveAlpha);
     }
 
     return result;

--- a/src/internal/models/IEffectActionModel.ts
+++ b/src/internal/models/IEffectActionModel.ts
@@ -150,6 +150,7 @@ interface IExtractModel extends IActionModel {
   detectMultiple?: boolean;
   mode?: ExtractModeType;
   invert?: boolean;
+  preserveAlpha?: boolean;
 }
 
 export {


### PR DESCRIPTION
### Pull request for @cloudinary/transformation-builder-sdk


#### What does this PR solve?
Add support for `preserve-alpha` attribute in `e_extract` action


#### Final checklist
- [x] Implementation is aligned to Spec.
- [x] Tests - Add proper tests to the added code.
